### PR TITLE
fix: update imports and decorators for langgraph 0.4.8 compatibility

### DIFF
--- a/src/nodes/generate_comment_node.py
+++ b/src/nodes/generate_comment_node.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import yaml
 import os
 
-from langgraph.graph import node
+# langgraph nodeデコレータは新バージョンでは不要
 
 from src.data.comment_generation_state import CommentGenerationState
 from src.llm.llm_manager import LLMManager
@@ -19,7 +19,6 @@ from src.data.comment_pair import CommentPair
 logger = logging.getLogger(__name__)
 
 
-@node
 def generate_comment_node(state: CommentGenerationState) -> CommentGenerationState:
     """
     LLMを使用してコメントを生成するノード。

--- a/src/nodes/input_node.py
+++ b/src/nodes/input_node.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import pytz
 
 from src.data.comment_generation_state import CommentGenerationState
-from src.data.location import Location
+from src.data.location_manager import Location
 
 logger = logging.getLogger(__name__)
 

--- a/src/nodes/weather_forecast_node.py
+++ b/src/nodes/weather_forecast_node.py
@@ -392,6 +392,30 @@ async def integrate_weather_into_conversation(
         return messages
 
 
+# ワークフロー用の関数
+async def fetch_weather_forecast_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    """ワークフロー用の天気予報取得ノード関数
+    
+    Args:
+        state: ワークフローの状態辞書
+        
+    Returns:
+        更新された状態辞書
+    """
+    # 環境変数からAPIキーを取得
+    import os
+    api_key = os.getenv('WXTECH_API_KEY')
+    if not api_key:
+        return {
+            **state,
+            'error_message': 'WXTECH_API_KEY環境変数が設定されていません'
+        }
+    
+    # WeatherForecastNodeを使用して天気予報を取得
+    weather_node = WeatherForecastNode(api_key)
+    return await weather_node.get_weather_forecast(state)
+
+
 if __name__ == "__main__":
     # テスト用コード
     import os

--- a/src/workflows/comment_generation_workflow.py
+++ b/src/workflows/comment_generation_workflow.py
@@ -7,8 +7,7 @@ LangGraphを使用した天気コメント生成のメインワークフロー�
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 import time
-from langgraph import StateGraph
-from langgraph.graph import END
+from langgraph.graph import StateGraph, END
 
 from src.data.comment_generation_state import CommentGenerationState
 from src.nodes.weather_forecast_node import fetch_weather_forecast_node


### PR DESCRIPTION
- Fix StateGraph import from langgraph.graph instead of langgraph
- Remove deprecated @node decorator from generate_comment_node
- Add fetch_weather_forecast_node function to weather_forecast_node
- Fix Location import path from location_manager module

These changes resolve import errors when running the Streamlit app with the updated langgraph package version.

🤖 Generated with [Claude Code](https://claude.ai/code)