### PR TITLE
晴天・猛暑時に「変わりやすい空」が選ばれる問題を修正

### DIFF
--- a/src/nodes/generate_comment_node.py
+++ b/src/nodes/generate_comment_node.py
@@ -71,17 +71,102 @@ def generate_comment_node(state: CommentGenerationState) -> CommentGenerationSta
         logger.critical(f"🚨 最終安全チェック開始: 天気='{weather_data.weather_description}', 気温={weather_data.temperature}°C")
         logger.critical(f"🚨 選択されたコメント: 天気='{weather_comment}', アドバイス='{advice_comment}'")
         
-        # 雨天で熱中症警告は絶対に不適切
-        if "雨" in weather_data.weather_description and weather_data.temperature < 30.0 and advice_comment and "熱中症" in advice_comment:
-            logger.critical(f"🚨 緊急修正: 雨天+低温で熱中症警告を除外")
-            advice_comment = "雨にご注意を"
-            logger.critical(f"🚨 アドバイス修正完了: '{advice_comment}'")
+        # 晴天・快晴時の「変わりやすい空」は絶対に不適切 - 既存コメントから再選択
+        if any(sunny in weather_data.weather_description for sunny in ["晴", "快晴", "猛暑"]) and weather_comment:
+            changeable_patterns = [
+                "変わりやすい空", "変わりやすい天気", "変わりやすい",
+                "変化しやすい空", "移ろいやすい空", "気まぐれな空", "不安定な空模様"
+            ]
+            for pattern in changeable_patterns:
+                if pattern in weather_comment:
+                    logger.critical(f"🚨 緊急修正: 晴天時に「{pattern}」は不適切 - 代替コメント検索")
+                    
+                    # stateから過去コメントデータを取得して適切なものを選択
+                    if state.past_weather_comments:
+                        # 気温に応じた適切なコメントのパターン
+                        if weather_data.temperature >= 35:
+                            preferred_patterns = ["猛烈な暑さ", "危険な暑さ", "猛暑に警戒", "激しい暑さ"]
+                        elif weather_data.temperature >= 30:
+                            preferred_patterns = ["厳しい暑さ", "強い日差し", "厳しい残暑", "強烈な日差し"]
+                        else:
+                            preferred_patterns = ["爽やかな晴天", "穏やかな空", "心地よい天気", "過ごしやすい天気"]
+                        
+                        # 既存コメントから適切なものを検索
+                        replacement_found = False
+                        for past_comment in state.past_weather_comments:
+                            comment_text = past_comment.comment_text
+                            # 優先パターンに一致するものを探す
+                            for preferred in preferred_patterns:
+                                if preferred in comment_text:
+                                    weather_comment = comment_text
+                                    logger.critical(f"🚨 代替コメント発見: '{weather_comment}'")
+                                    replacement_found = True
+                                    break
+                            if replacement_found:
+                                break
+                        
+                        # 優先パターンが見つからない場合、晴天系の任意のコメントを選択
+                        if not replacement_found:
+                            sunny_keywords = ["晴", "日差し", "太陽", "快晴", "青空"]
+                            for past_comment in state.past_weather_comments:
+                                comment_text = past_comment.comment_text
+                                if any(keyword in comment_text for keyword in sunny_keywords) and \
+                                   not any(ng in comment_text for ng in changeable_patterns):
+                                    weather_comment = comment_text
+                                    logger.critical(f"🚨 晴天系代替コメント: '{weather_comment}'")
+                                    replacement_found = True
+                                    break
+                        
+                        # それでも見つからない場合はデフォルト（最初の有効なコメント）
+                        if not replacement_found and state.past_weather_comments:
+                            weather_comment = state.past_weather_comments[0].comment_text
+                            logger.critical(f"🚨 デフォルト代替: '{weather_comment}'")
+                    else:
+                        logger.critical("🚨 代替コメントが見つからないため、デフォルト維持")
+                    
+                    break
         
-        # 大雨・嵐でムシムシ暑いは不適切
+        # 雨天で熱中症警告は絶対に不適切 - 既存コメントから再選択
+        if "雨" in weather_data.weather_description and weather_data.temperature < 30.0 and advice_comment and "熱中症" in advice_comment:
+            logger.critical(f"🚨 緊急修正: 雨天+低温で熱中症警告を除外 - 代替アドバイス検索")
+            
+            if state.past_advice_comments:
+                # 雨天に適したアドバイスを検索
+                rain_patterns = ["雨にご注意", "傘", "濡れ", "雨具", "足元", "滑り"]
+                replacement_found = False
+                
+                for past_comment in state.past_advice_comments:
+                    comment_text = past_comment.comment_text
+                    if any(pattern in comment_text for pattern in rain_patterns):
+                        advice_comment = comment_text
+                        logger.critical(f"🚨 雨天用代替アドバイス: '{advice_comment}'")
+                        replacement_found = True
+                        break
+                
+                if not replacement_found and state.past_advice_comments:
+                    advice_comment = state.past_advice_comments[0].comment_text
+                    logger.critical(f"🚨 デフォルト代替アドバイス: '{advice_comment}'")
+        
+        # 大雨・嵐でムシムシ暑いは不適切 - 既存コメントから再選択
         if ("大雨" in weather_data.weather_description or "嵐" in weather_data.weather_description) and weather_comment and "ムシムシ" in weather_comment:
-            logger.critical(f"🚨 緊急修正: 悪天候でムシムシコメントを除外")
-            weather_comment = "荒れた天気"
-            logger.critical(f"🚨 天気コメント修正完了: '{weather_comment}'")
+            logger.critical(f"🚨 緊急修正: 悪天候でムシムシコメントを除外 - 代替コメント検索")
+            
+            if state.past_weather_comments:
+                # 悪天候に適したコメントを検索
+                storm_patterns = ["荒れた天気", "大雨", "激しい雨", "暴風", "警戒", "注意", "本格的な雨"]
+                replacement_found = False
+                
+                for past_comment in state.past_weather_comments:
+                    comment_text = past_comment.comment_text
+                    if any(pattern in comment_text for pattern in storm_patterns):
+                        weather_comment = comment_text
+                        logger.critical(f"🚨 悪天候用代替コメント: '{weather_comment}'")
+                        replacement_found = True
+                        break
+                
+                if not replacement_found and state.past_weather_comments:
+                    weather_comment = state.past_weather_comments[0].comment_text
+                    logger.critical(f"🚨 デフォルト代替: '{weather_comment}'")
 
         # 最終コメント構成
         if weather_comment and advice_comment:


### PR DESCRIPTION
## 概要
晴れや快晴、猛暑の予報時に「変わりやすい空」という不適切なコメントが選ばれる問題を修正しました。

## 問題の原因
1. 「猛暑」が晴天条件の判定に含まれていなかった
2. CSVファイルに「変わりやすい空」が高使用回数（夏: 33,511回）で含まれていた
3. LLM API制限などでフォールバック処理が動いた際に不適切なコメントが選ばれていた

## 修正内容
### 1. WeatherCommentValidator強化
- 「猛暑」を晴天条件として追加
- 晴天時の「変わりやすい」表現の除外を強化

### 2. CommentSelector強化
- 追加の晴天時チェック機能を実装
- より多くの「変わりやすい」パターンを検出

### 3. 最終安全チェックの改善
- **新規生成ではなく、既存のCSVコメントから適切なものを再選択**
- 気温に応じた優先パターン：
  - 35°C以上: 「猛烈な暑さ」「危険な暑さ」「猛暑に警戒」
  - 30°C以上: 「厳しい暑さ」「強い日差し」「厳しい残暑」
  - それ未満: 「爽やかな晴天」「穏やかな空」「心地よい天気」

### 4. LLM選択プロンプト改善
- 晴天時の特別な注意事項を追加
- 安定した天気表現を選ぶよう明示的に指示

## テスト結果
```
選択前: 変わりやすい空
🚨 緊急修正: 晴天時に「変わりやすい空」は不適切 - 代替コメント検索
🚨 代替コメント発見: '厳しい暑さ'
修正後: 厳しい暑さ　熱中症対策を
```

## 3層防御システム
1. **第1層**: WeatherCommentValidatorで事前除外
2. **第2層**: CommentSelectorで追加チェック
3. **第3層**: 最終安全チェックで既存コメントから再選択

🤖 Generated with [Claude Code](https://claude.ai/code)