### PR TITLE
fix: Fix React API client request format for /api/generate endpoint

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -32,7 +32,7 @@ except ImportError as e:
 app = FastAPI(title="Mobile Comment Generator API", version="1.0.0")
 
 # CORS設定
-CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000").split(",")
+CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173").split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,
@@ -97,6 +97,7 @@ def get_history():
 @app.post("/api/generate", response_model=CommentGenerationResponse)
 def generate_comment(request: CommentGenerationRequest):
     """Generate weather comment for a location"""
+    logger.info(f"Received request: {request}")
     logger.info(f"Generating comment for location: {request.location}, provider: {request.llm_provider}")
     
     try:

--- a/shared/src/api/client.ts
+++ b/shared/src/api/client.ts
@@ -6,7 +6,10 @@ export class ApiClient {
 
   constructor(baseURL?: string) {
     // APIサーバーは8000番ポートで起動
-    const apiUrl = baseURL || process.env.NUXT_PUBLIC_API_URL || process.env.VITE_API_URL || 'http://localhost:8000';
+    const apiUrl = baseURL || 
+      (typeof process !== 'undefined' && process.env?.NUXT_PUBLIC_API_URL) || 
+      (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_URL) || 
+      'http://localhost:8000';
     
     this.client = axios.create({
       baseURL: apiUrl,
@@ -39,12 +42,51 @@ export class ApiClient {
 
   async getLocations(): Promise<Location[]> {
     const response = await this.client.get('/api/locations');
-    return response.data;
+    // APIは {locations: string[]} の形式で返すので、Location[]に変換
+    const locationNames = response.data.locations || response.data;
+    return Array.isArray(locationNames) 
+      ? locationNames.map((name: string, index: number) => ({
+          id: `loc-${index}`,
+          name,
+          prefecture: name, // 簡易的にnameをprefectureとして使用
+          region: name // 簡易的にnameをregionとして使用
+        }))
+      : [];
   }
 
   async generateComment(settings: GenerateSettings): Promise<GeneratedComment> {
-    const response = await this.client.post('/api/generate', settings);
-    return response.data;
+    // APIサーバーの期待する形式に変換
+    const apiRequest = {
+      location: settings.location.name,
+      llm_provider: settings.llmProvider,
+      target_datetime: settings.targetDateTime,
+    };
+    
+    const response = await this.client.post('/api/generate', apiRequest);
+    
+    // APIレスポンスをGeneratedComment形式に変換
+    const apiResponse = response.data;
+    return {
+      id: `comment-${Date.now()}`,
+      comment: apiResponse.comment || '',
+      adviceComment: apiResponse.metadata?.selected_advice_comment,
+      weather: {
+        current: {
+          temperature: apiResponse.metadata?.temperature || 0,
+          humidity: apiResponse.metadata?.humidity || 0,
+          pressure: 0,
+          windSpeed: apiResponse.metadata?.wind_speed || 0,
+          windDirection: '',
+          description: apiResponse.metadata?.weather_condition || '',
+          icon: '',
+        },
+        forecast: [],
+      },
+      timestamp: new Date().toISOString(),
+      confidence: apiResponse.success ? 0.9 : 0.1,
+      location: settings.location,
+      settings,
+    };
   }
 
   async getHistory(limit: number = 10): Promise<GeneratedComment[]> {


### PR DESCRIPTION
- Convert GenerateSettings to API expected format (location name string, llm_provider)
- Transform API response to GeneratedComment format
- Add request logging to API server for debugging
- Update CORS origins to include Vite dev server ports

🤖 Generated with [Claude Code](https://claude.ai/code)