### PR TITLE
fix: Add CORS support for React dev server on port 5174

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -32,7 +32,7 @@ except ImportError as e:
 app = FastAPI(title="Mobile Comment Generator API", version="1.0.0")
 
 # CORS設定
-CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173").split(",")
+CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174").split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,


### PR DESCRIPTION
- Updated CORS_ORIGINS to include localhost:5174 and 127.0.0.1:5174
- Fixes CORS errors when React app tries to access FastAPI server

🤖 Generated with [Claude Code](https://claude.ai/code)