### PR TITLE
fix: 安定した天気での「変わりやすい」コメント選択を修正

### DIFF
--- a/src/algorithms/evaluators/relevance_evaluator.py
+++ b/src/algorithms/evaluators/relevance_evaluator.py
@@ -50,6 +50,13 @@ class RelevanceEvaluator(BaseEvaluator):
                         has_contradiction = True
                         break
         
+        # 天気の安定性と矛盾する表現のチェック
+        if hasattr(context, 'weather_stability') and context.weather_stability == 'stable':
+            changeable_keywords = ["変わりやすい", "不安定", "急変", "めまぐるしく", "変化"]
+            if any(keyword in weather_comment or keyword in advice_comment for keyword in changeable_keywords):
+                has_contradiction = True
+                reasons.append("安定した天気なのに「変わりやすい」という表現")
+        
         if has_contradiction:
             score = 0.2
             reasons.append("天気条件と明らかに矛盾する表現")

--- a/src/config/weather_constants.py
+++ b/src/config/weather_constants.py
@@ -82,3 +82,13 @@ class StringLimits:
 HEATSTROKE_WARNING_TEMP = 34.0  # 熱中症警戒開始温度
 HEATSTROKE_SEVERE_TEMP = 35.0   # 熱中症厳重警戒温度
 COLD_WARNING_TEMP = 15.0        # 防寒対策が不要になる温度
+
+# 天気タイプ分類
+WEATHER_TYPE_KEYWORDS = {
+    'sunny': ["晴", "快晴"],
+    'cloudy': ["曇", "くもり", "うすぐもり", "薄曇"],
+    'rainy': ["雨", "rain"]
+}
+
+# 天気変化の閾値
+WEATHER_CHANGE_THRESHOLD = 2  # 「変わりやすい」と判定する変化回数の閾値

--- a/src/data/evaluation_criteria.py
+++ b/src/data/evaluation_criteria.py
@@ -145,6 +145,7 @@ class EvaluationContext:
         target_datetime: 対象日時
         user_preferences: ユーザー設定
         history: 過去の評価履歴
+        weather_stability: 天気の安定性 ('stable' または 'unstable')
     """
 
     weather_condition: str
@@ -152,6 +153,7 @@ class EvaluationContext:
     target_datetime: datetime
     user_preferences: Dict[str, Any] = field(default_factory=dict)
     history: List[Dict[str, Any]] = field(default_factory=list)
+    weather_stability: Optional[str] = None
 
     def get_preference(self, key: str, default: Any = None) -> Any:
         """ユーザー設定を取得"""

--- a/src/formatters/weather_timeline_formatter.py
+++ b/src/formatters/weather_timeline_formatter.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 import pytz
 
 from src.data.forecast_cache import ForecastCache, ensure_jst
+from src.utils.weather_classifier import classify_weather_type, count_weather_type_changes, is_morning_only_change
+from src.config.weather_constants import WEATHER_CHANGE_THRESHOLD
 
 logger = logging.getLogger(__name__)
 
@@ -124,26 +126,18 @@ class WeatherTimelineFormatter:
             # 天気タイプを時系列で分類
             weather_type_sequence = []
             for condition in weather_conditions:
-                condition_lower = condition.lower()
-                if any(sunny in condition_lower for sunny in ["晴", "快晴"]):
-                    weather_type_sequence.append("sunny")
-                elif any(cloudy in condition_lower for cloudy in ["曇", "くもり", "うすぐもり", "薄曇"]):
-                    weather_type_sequence.append("cloudy")
-                else:
-                    weather_type_sequence.append("other")
+                weather_type = classify_weather_type(condition)
+                weather_type_sequence.append(weather_type or "other")
             
             # タイプレベルでの変化回数をカウント
-            type_changes = 0
-            for i in range(1, len(weather_type_sequence)):
-                if weather_type_sequence[i] != weather_type_sequence[i-1]:
-                    type_changes += 1
+            type_changes = count_weather_type_changes(weather_type_sequence)
             
             # 判定ロジック
-            # 2回以上タイプが変わる（例：曇り→晴れ→曇り）場合は変わりやすい
-            if type_changes >= 2:
+            # WEATHER_CHANGE_THRESHOLD回以上タイプが変わる場合は変わりやすい
+            if type_changes >= WEATHER_CHANGE_THRESHOLD:
                 return "変わりやすい天気"
             # 朝だけ違って、その後同じ天気が続く場合は安定
-            elif type_changes == 1 and weather_type_sequence[1] == weather_type_sequence[2] == weather_type_sequence[3]:
+            elif type_changes == 1 and is_morning_only_change(weather_type_sequence):
                 return "安定した天気"
             # その他1回だけ変化する場合も基本的には安定
             elif type_changes <= 1:

--- a/src/formatters/weather_timeline_formatter.py
+++ b/src/formatters/weather_timeline_formatter.py
@@ -109,7 +109,44 @@ class WeatherTimelineFormatter:
             return "悪天候注意"
         elif has_rain:
             return "雨天続く"
-        elif len(set(weather_conditions)) <= 2:
-            return "安定した天気"
         else:
-            return "変わりやすい天気"
+            # 天気の変化を詳細に分析
+            # 全て同じ天気の場合
+            if len(set(weather_conditions)) == 1:
+                return "安定した天気"
+            
+            # 天気の変化回数をカウント
+            weather_changes = 0
+            for i in range(1, len(weather_conditions)):
+                if weather_conditions[i] != weather_conditions[i-1]:
+                    weather_changes += 1
+            
+            # 天気タイプを時系列で分類
+            weather_type_sequence = []
+            for condition in weather_conditions:
+                condition_lower = condition.lower()
+                if any(sunny in condition_lower for sunny in ["晴", "快晴"]):
+                    weather_type_sequence.append("sunny")
+                elif any(cloudy in condition_lower for cloudy in ["曇", "くもり", "うすぐもり", "薄曇"]):
+                    weather_type_sequence.append("cloudy")
+                else:
+                    weather_type_sequence.append("other")
+            
+            # タイプレベルでの変化回数をカウント
+            type_changes = 0
+            for i in range(1, len(weather_type_sequence)):
+                if weather_type_sequence[i] != weather_type_sequence[i-1]:
+                    type_changes += 1
+            
+            # 判定ロジック
+            # 2回以上タイプが変わる（例：曇り→晴れ→曇り）場合は変わりやすい
+            if type_changes >= 2:
+                return "変わりやすい天気"
+            # 朝だけ違って、その後同じ天気が続く場合は安定
+            elif type_changes == 1 and weather_type_sequence[1] == weather_type_sequence[2] == weather_type_sequence[3]:
+                return "安定した天気"
+            # その他1回だけ変化する場合も基本的には安定
+            elif type_changes <= 1:
+                return "安定した天気"
+            else:
+                return "変わりやすい天気"

--- a/src/nodes/comment_selector/validation.py
+++ b/src/nodes/comment_selector/validation.py
@@ -336,22 +336,16 @@ class CommentValidator:
         return False
     
     def _check_full_day_stability(self, weather_data: WeatherForecast, state: Optional[CommentGenerationState] = None) -> bool:
-        """翌日の全データから安定性を判定"""
-        # 現在の天気が「うすぐもり」「くもり」の場合も確認
-        current_desc = weather_data.weather_description.lower()
-        is_current_cloudy = any(cloudy in current_desc for cloudy in ["曇", "くもり", "うすぐもり", "薄曇"])
-        
+        """翌日の全データから安定性を判定（現在の天気は無視）"""
         if not state:
-            # stateがない場合は現在の天気データのみで判定
-            if is_current_cloudy and weather_data.precipitation <= 1.0 and weather_data.wind_speed <= 5.0:
-                return True
-            return weather_data.is_stable_weather()
+            # stateがない場合はデフォルトで不安定とする
+            return False
         
         # forecast_collectionを取得
         forecast_collection = state.generation_metadata.get('forecast_collection')
         if not forecast_collection or not hasattr(forecast_collection, 'forecasts'):
-            # 翌日のデータがない場合は現在のデータのみで判定
-            return weather_data.is_stable_weather()
+            # 翌日のデータがない場合は不安定とする
+            return False
         
         # 翌日の予報データを取得（9:00-18:00）
         import pytz
@@ -371,9 +365,10 @@ class CommentValidator:
             if forecast_dt.date() == tomorrow and forecast_dt.hour in target_hours:
                 next_day_forecasts.append(forecast)
         
-        if not next_day_forecasts:
-            # 翌日のデータがない場合は現在のデータのみで判定
-            return weather_data.is_stable_weather()
+        if len(next_day_forecasts) < 4:
+            # 4つの時間帯のデータが揃わない場合は不安定とする
+            logger.info(f"翌日のデータが不足: {len(next_day_forecasts)}件のみ")
+            return False
         
         # 全ての時間帯が同じ天気か確認
         weather_types = set()
@@ -388,28 +383,76 @@ class CommentValidator:
             else:
                 weather_types.add("other")
         
-        # 異なる天気タイプが複数ある場合は不安定
-        if len(weather_types) > 1:
-            logger.info(f"翌日の天気が変化: {weather_types}")
+        # 天気タイプの時系列を作成
+        weather_type_sequence = []
+        for forecast in next_day_forecasts:
+            desc = forecast.weather_description.lower()
+            if any(sunny in desc for sunny in ["晴", "快晴"]):
+                weather_type_sequence.append("sunny")
+            elif any(cloudy in desc for cloudy in ["曇", "くもり", "うすぐもり", "薄曇"]):
+                weather_type_sequence.append("cloudy")
+            elif any(rainy in desc for rainy in ["雨", "rain"]):
+                weather_type_sequence.append("rainy")
+            else:
+                weather_type_sequence.append("other")
+        
+        # 変化回数をカウント
+        type_changes = 0
+        for i in range(1, len(weather_type_sequence)):
+            if weather_type_sequence[i] != weather_type_sequence[i-1]:
+                type_changes += 1
+        
+        # 2回以上変化する場合は不安定（例：曇り→晴れ→曇り→晴れ）
+        if type_changes >= 2:
+            logger.info(f"翌日の天気が頻繁に変化: {weather_type_sequence}, 変化回数: {type_changes}")
             return False
         
-        # 全てが曇りの場合、追加条件を確認
-        if weather_types == {"cloudy"}:
-            # 降水量、風速、雷のチェック
-            for forecast in next_day_forecasts:
-                if forecast.precipitation > 1.0 or forecast.wind_speed > 5.0:
-                    logger.info(f"翌日の曇天が不安定: 降水量={forecast.precipitation}mm, 風速={forecast.wind_speed}m/s")
+        # 異なる天気タイプが複数ある場合でも、変化が1回だけなら追加チェック
+        if len(weather_types) > 1:
+            # 朝だけ違って、その後同じ天気が続く場合は安定とみなす
+            if type_changes == 1 and len(weather_type_sequence) >= 4:
+                if weather_type_sequence[1] == weather_type_sequence[2] == weather_type_sequence[3]:
+                    logger.info(f"朝だけ天気が異なるが、その後安定: {weather_type_sequence}")
+                    # 朝が曇りで日中晴れ続きなら安定
+                    if weather_type_sequence[0] == "cloudy" and weather_type_sequence[1] == "sunny":
+                        return True
+                    # 朝が晴れで日中曇り続きなら、追加条件確認へ
+                    elif weather_type_sequence[0] == "sunny" and weather_type_sequence[1] == "cloudy":
+                        # 曇りの安定性を確認（下の曇り判定へ）
+                        pass
+                else:
+                    logger.info(f"翌日の天気が変化: {weather_types}")
                     return False
-                if "雷" in forecast.weather_description or "thunder" in forecast.weather_description.lower():
-                    logger.info("翌日に雷が含まれるため不安定")
-                    return False
-            logger.info("翌日は安定した曇天")
-            return True
+            else:
+                logger.info(f"翌日の天気が変化: {weather_types}")
+                return False
         
-        # 全てが晴れの場合は安定
-        if weather_types == {"sunny"}:
-            logger.info("翌日は安定した晴天")
-            return True
+        # 単一の天気タイプの場合、その種類に応じて判定
+        if len(weather_types) == 1:
+            weather_type = list(weather_types)[0]
+            
+            # 全てが晴れの場合は安定
+            if weather_type == "sunny":
+                logger.info("翌日は終日晴天で安定")
+                return True
+            
+            # 全てが曇りの場合、追加条件を確認
+            elif weather_type == "cloudy":
+                # 降水量、風速、雷のチェック
+                for forecast in next_day_forecasts:
+                    if forecast.precipitation > 1.0 or forecast.wind_speed > 10.0:
+                        logger.info(f"翌日の曇天が不安定: 降水量={forecast.precipitation}mm, 風速={forecast.wind_speed}m/s")
+                        return False
+                    if "雷" in forecast.weather_description or "thunder" in forecast.weather_description.lower():
+                        logger.info("翌日に雷が含まれるため不安定")
+                        return False
+                logger.info("翌日は終日曇天で安定")
+                return True
+            
+            # 雨の場合は不安定とする
+            else:
+                logger.info(f"翌日の天気タイプ「{weather_type}」は不安定")
+                return False
         
         # その他の場合は不安定
         return False

--- a/src/nodes/comment_selector/validation.py
+++ b/src/nodes/comment_selector/validation.py
@@ -10,6 +10,8 @@ from src.data.weather_data import WeatherForecast
 from src.data.comment_generation_state import CommentGenerationState
 from src.utils.weather_comment_validator import WeatherCommentValidator
 from src.utils.common_utils import SEVERE_WEATHER_PATTERNS, FORBIDDEN_PHRASES
+from src.utils.weather_classifier import classify_weather_type, count_weather_type_changes
+from src.config.weather_constants import WEATHER_CHANGE_THRESHOLD
 
 logger = logging.getLogger(__name__)
 
@@ -370,40 +372,17 @@ class CommentValidator:
             logger.info(f"翌日のデータが不足: {len(next_day_forecasts)}件のみ")
             return False
         
-        # 全ての時間帯が同じ天気か確認
-        weather_types = set()
-        for forecast in next_day_forecasts:
-            desc = forecast.weather_description.lower()
-            if any(sunny in desc for sunny in ["晴", "快晴"]):
-                weather_types.add("sunny")
-            elif any(cloudy in desc for cloudy in ["曇", "くもり", "うすぐもり", "薄曇"]):
-                weather_types.add("cloudy")
-            elif any(rainy in desc for rainy in ["雨", "rain"]):
-                weather_types.add("rainy")
-            else:
-                weather_types.add("other")
-        
         # 天気タイプの時系列を作成
-        weather_type_sequence = []
-        for forecast in next_day_forecasts:
-            desc = forecast.weather_description.lower()
-            if any(sunny in desc for sunny in ["晴", "快晴"]):
-                weather_type_sequence.append("sunny")
-            elif any(cloudy in desc for cloudy in ["曇", "くもり", "うすぐもり", "薄曇"]):
-                weather_type_sequence.append("cloudy")
-            elif any(rainy in desc for rainy in ["雨", "rain"]):
-                weather_type_sequence.append("rainy")
-            else:
-                weather_type_sequence.append("other")
+        weather_type_sequence = self._get_weather_type_sequence(next_day_forecasts)
+        
+        # 全ての時間帯が同じ天気か確認
+        weather_types = set(weather_type_sequence)
         
         # 変化回数をカウント
-        type_changes = 0
-        for i in range(1, len(weather_type_sequence)):
-            if weather_type_sequence[i] != weather_type_sequence[i-1]:
-                type_changes += 1
+        type_changes = count_weather_type_changes(weather_type_sequence)
         
-        # 2回以上変化する場合は不安定（例：曇り→晴れ→曇り→晴れ）
-        if type_changes >= 2:
+        # WEATHER_CHANGE_THRESHOLD回以上変化する場合は不安定
+        if type_changes >= WEATHER_CHANGE_THRESHOLD:
             logger.info(f"翌日の天気が頻繁に変化: {weather_type_sequence}, 変化回数: {type_changes}")
             return False
         
@@ -622,3 +601,12 @@ class CommentValidator:
         if not comment_condition:
             return True
         return comment_condition.lower() in weather_description.lower()
+    
+    def _get_weather_type_sequence(self, forecasts: List) -> List[str]:
+        """天気予報リストから天気タイプのシーケンスを生成"""
+        weather_type_sequence = []
+        for forecast in forecasts:
+            desc = forecast.weather_description
+            weather_type = classify_weather_type(desc)
+            weather_type_sequence.append(weather_type or "other")
+        return weather_type_sequence

--- a/src/nodes/evaluate_candidate_node.py
+++ b/src/nodes/evaluate_candidate_node.py
@@ -48,6 +48,11 @@ def evaluate_candidate_node(state: CommentGenerationState) -> CommentGenerationS
         comment_pair = _restore_comment_pair(selected_pair_data)
         weather_data = _restore_weather_data(weather_data_dict)
 
+        # 天気の安定性を判定（validation.pyのロジックを再利用）
+        from src.nodes.comment_selector.validation import CommentValidator
+        validator = CommentValidator()
+        is_stable = validator._check_full_day_stability(weather_data, state)
+        
         # 評価コンテキストの作成
         context = EvaluationContext(
             weather_condition=weather_data.weather_description,
@@ -56,6 +61,9 @@ def evaluate_candidate_node(state: CommentGenerationState) -> CommentGenerationS
             user_preferences=user_preferences,
             history=getattr(state, "evaluation_history", []),
         )
+        
+        # 天気の安定性情報を追加
+        context.weather_stability = 'stable' if is_stable else 'unstable'
 
         # 評価器の初期化（カスタム重みがあれば使用）
         custom_weights = _get_custom_weights(user_preferences)

--- a/src/nodes/evaluate_candidate_node.py
+++ b/src/nodes/evaluate_candidate_node.py
@@ -65,10 +65,8 @@ def evaluate_candidate_node(state: CommentGenerationState) -> CommentGenerationS
             target_datetime=target_datetime,
             user_preferences=user_preferences,
             history=getattr(state, "evaluation_history", []),
+            weather_stability='stable' if is_stable else 'unstable'
         )
-        
-        # 天気の安定性情報を追加
-        context.weather_stability = 'stable' if is_stable else 'unstable'
 
         # 評価器の初期化（カスタム重みがあれば使用）
         custom_weights = _get_custom_weights(user_preferences)

--- a/src/nodes/evaluate_candidate_node.py
+++ b/src/nodes/evaluate_candidate_node.py
@@ -50,7 +50,12 @@ def evaluate_candidate_node(state: CommentGenerationState) -> CommentGenerationS
 
         # 天気の安定性を判定（validation.pyのロジックを再利用）
         from src.nodes.comment_selector.validation import CommentValidator
-        validator = CommentValidator()
+        from src.utils.weather_comment_validator import WeatherCommentValidator
+        from src.config.severe_weather_config import SevereWeatherConfig
+        
+        weather_validator = WeatherCommentValidator()
+        severe_config = SevereWeatherConfig()
+        validator = CommentValidator(weather_validator, severe_config)
         is_stable = validator._check_full_day_stability(weather_data, state)
         
         # 評価コンテキストの作成

--- a/src/utils/weather_classifier.py
+++ b/src/utils/weather_classifier.py
@@ -1,0 +1,66 @@
+"""天気タイプ分類ユーティリティ"""
+
+from typing import Optional
+from src.config.weather_constants import WEATHER_TYPE_KEYWORDS
+
+
+def classify_weather_type(weather_desc: str) -> Optional[str]:
+    """
+    天気説明文から天気タイプを分類
+    
+    Args:
+        weather_desc: 天気の説明文
+        
+    Returns:
+        'sunny', 'cloudy', 'rainy', None のいずれか
+    """
+    if not weather_desc:
+        return None
+        
+    weather_desc_lower = weather_desc.lower()
+    
+    # 各タイプのキーワードをチェック
+    for weather_type, keywords in WEATHER_TYPE_KEYWORDS.items():
+        if any(keyword in weather_desc for keyword in keywords):
+            return weather_type
+            
+    return None
+
+
+def count_weather_type_changes(weather_types: list[Optional[str]]) -> int:
+    """
+    天気タイプの変化回数をカウント
+    
+    Args:
+        weather_types: 天気タイプのリスト
+        
+    Returns:
+        変化回数
+    """
+    if not weather_types or len(weather_types) < 2:
+        return 0
+        
+    changes = 0
+    for i in range(1, len(weather_types)):
+        if weather_types[i] != weather_types[i-1]:
+            changes += 1
+            
+    return changes
+
+
+def is_morning_only_change(weather_types: list[Optional[str]]) -> bool:
+    """
+    朝だけ天気が違って、その後同じ天気が続くパターンかチェック
+    
+    Args:
+        weather_types: 天気タイプのリスト（時系列順）
+        
+    Returns:
+        朝だけ変化パターンかどうか
+    """
+    if len(weather_types) < 4:
+        return False
+        
+    # 最初の時間帯（朝）が異なり、その後の3つの時間帯が同じ場合
+    return (weather_types[0] != weather_types[1] and 
+            weather_types[1] == weather_types[2] == weather_types[3])


### PR DESCRIPTION
- 天気パターン判定ロジックを改善
  - 朝だけ違って日中同じ天気が続く場合は「安定」と判定
  - 2回以上変化する場合のみ「変わりやすい」と判定
- 表示とコメント選択ロジックの一貫性を確保
  - weather_timeline_formatter.pyの表示ロジックを修正
  - validation.pyの安定性判定を翌日データのみで実施

🤖 Generated with [Claude Code](https://claude.ai/code)