### PR TITLE
refactor: app.pyをMVCパターンで分離

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,81 +7,6 @@ from app_session_manager import SessionManager
 from app_view import CommentGenerationView
 
 
-def generate_with_progress(controller: CommentGenerationController, view: CommentGenerationView,
-                          locations: list, llm_provider: str, results_container):
-    """プログレスバー付きでコメントを生成"""
-    # ヘッダーを一度だけ表示
-    with results_container.container():
-        st.markdown("### 🌤️ 生成結果")
-
-    # プログレスUI作成
-    progress_bar, status_text = view.create_progress_ui()
-
-    # 生成中フラグを立てる
-    SessionManager.set_generating(True)
-
-    # 結果を格納する変数を事前に初期化
-    all_results = []
-
-    try:
-        # 進捗コールバック関数
-        def progress_callback(idx, total, location):
-            view.update_progress(progress_bar, status_text, idx, total, location)
-
-            # 中間結果の表示（前のインデックスまでの結果を取得）
-            if idx > 0 and all_results:
-                # 既に生成済みの結果を表示
-                with results_container.container():
-                    for i in range(min(idx, len(all_results))):
-                        result = all_results[i]
-                        metadata = controller.extract_weather_metadata(result)
-                        if 'forecast_time' in metadata and metadata['forecast_time']:
-                            metadata['forecast_time'] = controller.format_forecast_time(metadata['forecast_time'])
-                        view.display_single_result(result, metadata)
-
-        # 各地点を順番に処理
-        for idx, location in enumerate(locations):
-            progress_callback(idx, len(locations), location)
-
-            # 単一地点の生成
-            location_result = controller.generate_comment_for_location(location, llm_provider)
-            all_results.append(location_result)
-
-            # 結果を即座に表示
-            with results_container.container():
-                metadata = controller.extract_weather_metadata(location_result)
-                if 'forecast_time' in metadata and metadata['forecast_time']:
-                    metadata['forecast_time'] = controller.format_forecast_time(metadata['forecast_time'])
-                view.display_single_result(location_result, metadata)
-
-        # 最終結果を集計
-        success_count = sum(1 for r in all_results if r['success'])
-        errors = [r for r in all_results if not r['success']]
-        error_messages = []
-
-        for err in errors:
-            location = err['location']
-            error_msg = err.get('error', '不明なエラー')
-            error_messages.append(f"{location}: {error_msg}")
-
-        result = {
-            'success': success_count > 0,
-            'total_locations': len(locations),
-            'success_count': success_count,
-            'results': all_results,
-            'final_comment': '\n'.join([f"{r['location']}: {r['comment']}" for r in all_results if r['success']]),
-            'errors': error_messages
-        }
-
-        # 完了処理
-        view.complete_progress(progress_bar, status_text, success_count, len(locations))
-
-        return result
-
-    finally:
-        SessionManager.set_generating(False)
-
-
 def main():
     """メインアプリケーション"""
     # コントローラーとビューの初期化
@@ -132,7 +57,7 @@ def main():
                         location = location[:controller.config.ui_settings.max_locations_per_generation]
 
                     # プログレスバー付き生成
-                    result = generate_with_progress(controller, view, location, llm_provider, results_container)
+                    result = controller.generate_with_progress(location, llm_provider, view, results_container)
                 else:
                     view.display_no_location_error()
                     result = None

--- a/app.py
+++ b/app.py
@@ -1,385 +1,169 @@
-"""天気コメント生成システム - Streamlit UI"""
+"""天気コメント生成システム - Streamlit UIエントリーポイント"""
 
 import streamlit as st
-from src.config.app_config import get_config
 
-# 設定の読み込み
-config = get_config()
+from app_controller import CommentGenerationController
+from app_view import CommentGenerationView
 
-# ページ設定（最初に呼ぶ必要がある）
-st.set_page_config(
-    page_title=config.ui_settings.page_title,
-    page_icon=config.ui_settings.page_icon,
-    layout=config.ui_settings.layout,
-    initial_sidebar_state=config.ui_settings.sidebar_state
-)
 
-from datetime import datetime
-import logging
-import time
-import pytz
-from typing import List, Optional
-
-from src.workflows.comment_generation_workflow import run_comment_generation
-from src.ui.streamlit_components import (
-    location_selector,
-    llm_provider_selector,
-    result_display,
-    generation_history_display,
-    settings_panel
-)
-from src.ui.streamlit_utils import save_to_history, load_history, load_locations, format_timestamp
-from src.utils.error_handler import ErrorHandler, with_error_handling
-from src.types import (
-    BatchGenerationResult,
-    LocationResult,
-    GenerationResult,
-    LLMProvider
-)
-
-logger = logging.getLogger(__name__)
-
-def initialize_session_state():
+def initialize_session_state(controller: CommentGenerationController):
     """セッション状態の初期化"""
     defaults = {
-        'generation_history': load_history(),
-        'selected_location': load_locations(),  # 全地点がデフォルト
-        'llm_provider': config.ui_settings.default_llm_provider,
+        'generation_history': controller.generation_history,
+        'selected_location': controller.get_default_locations(),
+        'llm_provider': controller.get_default_llm_provider(),
         'current_result': None,
         'is_generating': False,
-        'config': config
+        'config': controller.config
     }
-    
+
     for key, value in defaults.items():
         if key not in st.session_state:
             st.session_state[key] = value
 
 
-def display_single_result(result: LocationResult):
-    """個別の結果を表示（累積表示を避ける）"""
-    location = result['location']
-    success = result['success']
-    comment = result.get('comment', '')
-    error = result.get('error', '')
-    source_files = result.get('source_files', [])
-    
-    if success:
-        st.success(f"✅ **{location}**: {comment}")
-        
-        # メタデータがある場合は天気情報も表示
-        if result.get('result') and result['result'].get('generation_metadata'):
-            metadata = result['result']['generation_metadata']
-            with st.expander(f"📊 {location}の詳細情報"):
-                # 天気予報時刻の表示
-                forecast_time = metadata.get('weather_forecast_time')
-                if forecast_time:
-                    try:
-                        # UTC時刻をパース
-                        dt = datetime.fromisoformat(forecast_time.replace('Z', '+00:00'))
-                        # JSTに変換
-                        jst = pytz.timezone('Asia/Tokyo')
-                        dt_jst = dt.astimezone(jst)
-                        st.info(f"⏰ 予報時刻: {dt_jst.strftime('%Y年%m月%d日 %H時')}")
-                    except Exception as e:
-                        logger.warning(f"予報時刻のパース失敗: {e}, forecast_time={forecast_time}")
-                        st.info(f"⏰ 予報時刻: {forecast_time}")
-                
-                # 天気データの表示
-                col1, col2 = st.columns(2)
-                with col1:
-                    temp = metadata.get('temperature')
-                    if temp is not None:
-                        st.text(f"🌡️ 気温: {temp}°C")
-                    
-                    weather = metadata.get('weather_condition')
-                    if weather and weather != '不明':
-                        st.text(f"☁️ 天気: {weather}")
-                
-                with col2:
-                    wind = metadata.get('wind_speed')
-                    if wind is not None:
-                        st.text(f"💨 風速: {wind}m/s")
-                    
-                    humidity = metadata.get('humidity')
-                    if humidity is not None:
-                        st.text(f"💧 湿度: {humidity}%")
-                
-                # 選択されたコメントペア
-                selection_meta = metadata.get('selection_metadata', {})
-                if selection_meta:
-                    st.markdown("**🎯 選択されたコメント:**")
-                    weather_comment = selection_meta.get('selected_weather_comment')
-                    advice_comment = selection_meta.get('selected_advice_comment')
-                    
-                    if weather_comment:
-                        st.text(f"天気: {weather_comment}")
-                    if advice_comment:
-                        st.text(f"アドバイス: {advice_comment}")
-                    
-                    # LLMプロバイダー情報
-                    provider = selection_meta.get('llm_provider')
-                    if provider:
-                        st.text(f"選択方法: LLM ({provider})")
-    else:
-        st.error(f"❌ **{location}**: {error}")
-
-
-def display_streaming_results(results: List[LocationResult]):
-    """結果をストリーミング表示（従来関数・最終結果用）"""
-    # ヘッダーはgenerate_comment_with_progressで表示済み
-    
-    for result in results:
-        display_single_result(result)
-    
-    # 残りの地点数を表示
-    remaining = len([r for r in results if not r['success'] and not r.get('error')])
-    if remaining > 0:
-        st.info(f"⏳ 生成待ち: {remaining}地点")
-
-
-def generate_comment_with_progress(locations: List[str], llm_provider: str, results_container) -> BatchGenerationResult:
-    """プログレスバー付きコメント生成（複数地点対応）"""
-    if not locations:
-        return {'success': False, 'error': '地点が選択されていません'}
-    
-    progress_bar = st.progress(0)
-    status_text = st.empty()
-    
-    all_results = []
-    total_locations = len(locations)
-    
+def generate_with_progress(controller: CommentGenerationController, view: CommentGenerationView,
+                          locations: list, llm_provider: str, results_container):
+    """プログレスバー付きでコメントを生成"""
     # ヘッダーを一度だけ表示
     with results_container.container():
         st.markdown("### 🌤️ 生成結果")
-    
+
+    # プログレスUI作成
+    progress_bar, status_text = view.create_progress_ui()
+
+    # 生成中フラグを立てる
+    st.session_state.is_generating = True
+
     try:
-        # ワークフロー実行の開始
-        st.session_state.is_generating = True
-        
+        # 進捗コールバック関数
+        def progress_callback(idx, total, location):
+            view.update_progress(progress_bar, status_text, idx, total, location)
+
+            # 中間結果の表示（前のインデックスまでの結果を取得）
+            if idx > 0:
+                # 既に生成済みの結果を表示
+                with results_container.container():
+                    for i in range(idx):
+                        if i < len(all_results):
+                            result = all_results[i]
+                            metadata = controller.extract_weather_metadata(result)
+                            if 'forecast_time' in metadata and metadata['forecast_time']:
+                                metadata['forecast_time'] = controller.format_forecast_time(metadata['forecast_time'])
+                            view.display_single_result(result, metadata)
+
+        # バッチ生成実行
+        all_results = []
+
+        # 各地点を順番に処理
         for idx, location in enumerate(locations):
-            # 進捗更新
-            progress = (idx / total_locations)
-            progress_bar.progress(progress)
-            status_text.text(f"生成中... {location} ({idx + 1}/{total_locations})")
-            
-            try:
-                # 実際のコメント生成
-                result = run_comment_generation(
-                    location_name=location,
-                    target_datetime=datetime.now(),
-                    llm_provider=llm_provider
-                )
-                
-                # 結果を収集
-                location_result = {
-                    'location': location,
-                    'result': result,
-                    'success': result.get('success', False),
-                    'comment': result.get('final_comment', ''),
-                    'error': result.get('error', None)
-                }
-                
-                # ソースファイル情報を抽出
-                metadata = result.get('generation_metadata', {})
-                if metadata.get('selected_past_comments'):
-                    sources = []
-                    for comment in metadata['selected_past_comments']:
-                        if 'source_file' in comment:
-                            sources.append(comment['source_file'])
-                    if sources:
-                        location_result['source_files'] = sources
-                        # 詳細ログ出力
-                        logger.info(f"地点: {location}")
-                        logger.info(f"  天気: {metadata.get('weather_condition', '不明')}")
-                        logger.info(f"  気温: {metadata.get('temperature', '不明')}°C")
-                        logger.info(f"  コメント生成元ファイル: {sources}")
-                        logger.info(f"  生成コメント: {result.get('final_comment', '')}")
-                
-                all_results.append(location_result)
-                
-                # 個別地点の結果を追加表示（累積表示を避ける）
-                with results_container.container():
-                    display_single_result(location_result)
-                
-                # 履歴に保存
-                if result.get('success'):
-                    save_to_history(result, location, llm_provider)
-                    
-            except Exception as location_error:
-                # 個別地点のエラーをキャッチして記録
-                location_result = ErrorHandler.create_error_result(location, location_error)
-                all_results.append(location_result)
-                
-                # 個別地点の結果を追加表示（累積表示を避ける）
-                with results_container.container():
-                    display_single_result(location_result)
-        
-        # 完了
-        progress_bar.progress(1.0)
-        
-        # 成功数をカウント
+            progress_callback(idx, len(locations), location)
+
+            # 単一地点の生成
+            location_result = controller.generate_comment_for_location(location, llm_provider)
+            all_results.append(location_result)
+
+            # 結果を即座に表示
+            with results_container.container():
+                metadata = controller.extract_weather_metadata(location_result)
+                if 'forecast_time' in metadata and metadata['forecast_time']:
+                    metadata['forecast_time'] = controller.format_forecast_time(metadata['forecast_time'])
+                view.display_single_result(location_result, metadata)
+
+        # 最終結果を集計
         success_count = sum(1 for r in all_results if r['success'])
-        
-        if success_count > 0:
-            status_text.text(f"完了！{success_count}/{total_locations}地点の生成が成功しました")
-        else:
-            status_text.text("エラー：すべての地点でコメント生成に失敗しました")
-        
-        time.sleep(0.5)
-        
-        # エラーがあった場合は詳細を収集
         errors = [r for r in all_results if not r['success']]
         error_messages = []
-        
+
         for err in errors:
             location = err['location']
             error_msg = err.get('error', '不明なエラー')
             error_messages.append(f"{location}: {error_msg}")
-        
-        return {
+
+        result = {
             'success': success_count > 0,
-            'total_locations': total_locations,
+            'total_locations': len(locations),
             'success_count': success_count,
             'results': all_results,
             'final_comment': '\n'.join([f"{r['location']}: {r['comment']}" for r in all_results if r['success']]),
             'errors': error_messages
         }
-        
-    except Exception as e:
-        # 統一されたエラーハンドリング
-        error_response = ErrorHandler.handle_error(e)
-        st.error(error_response.user_message)
-        if error_response.hint:
-            st.info(f"💡 ヒント: {error_response.hint}")
-        
-        return {
-            'success': False,
-            'error': error_response.error_message,
-            'final_comment': None
-        }
+
+        # 完了処理
+        view.complete_progress(progress_bar, status_text, success_count, len(locations))
+
+        return result
+
     finally:
         st.session_state.is_generating = False
-        progress_bar.empty()
-        status_text.empty()
 
 
 def main():
     """メインアプリケーション"""
-    # 設定の検証
-    validation_results = config.validate()
-    
-    # 必須APIキーの確認
-    if not validation_results["api_keys"]["wxtech"]:
-        st.error("⚠️ WXTECH_API_KEYが設定されていません。天気予報データの取得ができません。")
-    
-    # デバッグモードでの追加情報表示
-    if config.debug and config.ui_settings.show_debug_info:
-        with st.expander("デバッグ情報", expanded=False):
-            st.json(config.to_dict())
-    
+    # コントローラーとビューの初期化
+    controller = CommentGenerationController()
+    view = CommentGenerationView()
+
+    # ページ設定（最初に呼ぶ必要がある）
+    view.setup_page_config(controller.config)
+
     # セッション状態の初期化
-    initialize_session_state()
-    
-    # ヘッダー
-    st.markdown('<h1 class="main-header">☀️ 天気コメント生成システム ☀️</h1>', unsafe_allow_html=True)
-    
-    # サイドバー
-    with st.sidebar:
-        st.header("設定")
-        
-        # APIキー設定
-        with st.expander("APIキー設定", expanded=False):
-            settings_panel()
-        
-        # 生成履歴
-        st.header("生成履歴")
-        generation_history_display(st.session_state.generation_history)
-    
+    initialize_session_state(controller)
+
+    # 設定の検証とAPIキー警告
+    validation_results = controller.validate_configuration()
+    view.display_api_key_warning(validation_results)
+
+    # デバッグ情報表示
+    view.display_debug_info(controller.config)
+
+    # ヘッダー表示
+    view.display_header()
+
+    # サイドバー設定
+    view.setup_sidebar(st.session_state.generation_history)
+
     # メインコンテンツ
     col1, col2 = st.columns([1, 2])
-    
+
     with col1:
-        st.header("📍 入力設定")
-        
-        # 地点選択
-        location = location_selector()
+        # 入力パネル
+        location, llm_provider = view.display_input_panel()
         st.session_state.selected_location = location
-        
-        # LLMプロバイダー選択
-        llm_provider = llm_provider_selector()
         st.session_state.llm_provider = llm_provider
-        
-        # 現在時刻表示
-        st.info(f"🕐 生成時刻: {format_timestamp(datetime.now())}")
-        
+
         # 生成ボタン
-        if st.button(
-            "🎯 コメント生成",
-            type="primary",
-            disabled=st.session_state.is_generating,
-            use_container_width=True
-        ):
+        if view.display_generation_button(st.session_state.is_generating):
             # 結果表示用のコンテナを先に作成
-            # col2の内容をクリアしてから新しいコンテナを作成
             col2.empty()
             results_container = col2.container()
-            
+
             with st.spinner("生成中..."):
                 # 複数地点の処理
                 if isinstance(location, list) and len(location) > 0:
-                    # 最大地点数のチェック
-                    if len(location) > config.ui_settings.max_locations_per_generation:
-                        st.warning(f"⚠️ 選択された地点数が上限（{config.ui_settings.max_locations_per_generation}地点）を超えています。")
-                        location = location[:config.ui_settings.max_locations_per_generation]
-                    result = generate_comment_with_progress(location, llm_provider, results_container)
+                    # 地点数の検証
+                    is_valid, error_msg = controller.validate_location_count(location)
+                    if not is_valid:
+                        view.display_location_warning(controller.config.ui_settings.max_locations_per_generation)
+                        location = location[:controller.config.ui_settings.max_locations_per_generation]
+
+                    # プログレスバー付き生成
+                    result = generate_with_progress(controller, view, location, llm_provider, results_container)
                 else:
-                    st.error("地点が選択されていません")
+                    view.display_no_location_error()
                     result = None
+
                 st.session_state.current_result = result
-                
-                if result and result['success']:
-                    st.success(f"✅ コメント生成が完了しました！ ({result['success_count']}/{result['total_locations']}地点成功)")
-                    if result['success_count'] == result['total_locations']:
-                        st.balloons()
-                    # 一部失敗した場合のエラー表示
-                    if result.get('errors'):
-                        with st.expander("⚠️ エラー詳細"):
-                            for error in result['errors']:
-                                st.warning(error)
-                elif result:
-                    # すべて失敗した場合はerrorメッセージをわかりやすく表示
-                    if result.get('errors'):
-                        for error in result['errors']:
-                            st.error(error)
-    
+
+                # 完了メッセージ
+                view.display_generation_complete(result)
+
     with col2:
-        st.header("💬 生成結果")
-        
-        # 生成中でない場合のみ固定の結果を表示
-        if not st.session_state.is_generating:
-            if st.session_state.current_result:
-                result_display(st.session_state.current_result)
-            else:
-                st.info("👈 左側のパネルから地点とLLMプロバイダーを選択して、「コメント生成」ボタンをクリックしてください。")
-            
-            # サンプル表示
-            with st.expander("サンプルコメント"):
-                st.markdown("""
-                **晴れの日**: 爽やかな朝ですね  
-                **雨の日**: 傘をお忘れなく  
-                **曇りの日**: 過ごしやすい一日です  
-                **雪の日**: 足元にお気をつけて
-                """)
-    
+        # 結果セクション
+        view.display_results_section(st.session_state.current_result, st.session_state.is_generating)
+
     # フッター
-    st.markdown("---")
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        st.markdown("**Version**: 1.0.0")
-    with col2:
-        st.markdown("**Last Updated**: 2025-06-06")
-    with col3:
-        st.markdown("**By**: WNI Team")
+    view.display_footer()
 
 
 def run_streamlit_app():

--- a/app_constants.py
+++ b/app_constants.py
@@ -1,32 +1,68 @@
 """天気コメント生成システム - UI定数定義"""
 
 
-class UIConstants:
-    """UI関連の定数定義"""
+class ProgressConstants:
+    """プログレス関連の定数"""
+    COMPLETE_DELAY = 0.5  # プログレス完了後の待機時間（秒）
+    UPDATE_INTERVAL = 0.1  # プログレス更新間隔（秒）
 
-    # プログレス関連
-    PROGRESS_COMPLETE_DELAY = 0.5  # プログレス完了後の待機時間（秒）
-    PROGRESS_UPDATE_INTERVAL = 0.1  # プログレス更新間隔（秒）
 
-    # レイアウト関連
+class LayoutConstants:
+    """レイアウト関連の定数"""
     DEFAULT_COLUMN_RATIO = [1, 2]  # デフォルトのカラム比率
     SIDEBAR_MIN_WIDTH = 300  # サイドバー最小幅（ピクセル）
 
-    # 表示関連
+
+class DisplayConstants:
+    """表示関連の定数"""
     MAX_DISPLAY_HISTORY = 10  # 履歴表示の最大数
     COMMENT_PREVIEW_LENGTH = 100  # コメントプレビューの最大文字数
-
-    # エラー表示
     ERROR_DISPLAY_DURATION = 5  # エラー表示時間（秒）
 
+
+class IconConstants:
+    """アイコン関連の定数"""
+    WEATHER = "🌤️"
+    LOCATION = "📍"
+    TIME = "⏰"
+    TEMPERATURE = "🌡️"
+    WIND = "💨"
+    HUMIDITY = "💧"
+    SUCCESS = "✅"
+    ERROR = "❌"
+    WARNING = "⚠️"
+    INFO = "ℹ️"
+    CLOUD = "☁️"
+    TARGET = "🎯"
+    DETAIL = "📊"
+    CALENDAR = "📅"
+
+
+# 互換性のためのエイリアス（段階的な移行用）
+class UIConstants:
+    """UI関連の定数定義（非推奨：個別のクラスを使用してください）"""
+    
+    # プログレス関連
+    PROGRESS_COMPLETE_DELAY = ProgressConstants.COMPLETE_DELAY
+    PROGRESS_UPDATE_INTERVAL = ProgressConstants.UPDATE_INTERVAL
+    
+    # レイアウト関連
+    DEFAULT_COLUMN_RATIO = LayoutConstants.DEFAULT_COLUMN_RATIO
+    SIDEBAR_MIN_WIDTH = LayoutConstants.SIDEBAR_MIN_WIDTH
+    
+    # 表示関連
+    MAX_DISPLAY_HISTORY = DisplayConstants.MAX_DISPLAY_HISTORY
+    COMMENT_PREVIEW_LENGTH = DisplayConstants.COMMENT_PREVIEW_LENGTH
+    ERROR_DISPLAY_DURATION = DisplayConstants.ERROR_DISPLAY_DURATION
+    
     # アイコン
-    ICON_WEATHER = "🌤️"
-    ICON_LOCATION = "📍"
-    ICON_TIME = "⏰"
-    ICON_TEMPERATURE = "🌡️"
-    ICON_WIND = "💨"
-    ICON_HUMIDITY = "💧"
-    ICON_SUCCESS = "✅"
-    ICON_ERROR = "❌"
-    ICON_WARNING = "⚠️"
-    ICON_INFO = "ℹ️"
+    ICON_WEATHER = IconConstants.WEATHER
+    ICON_LOCATION = IconConstants.LOCATION
+    ICON_TIME = IconConstants.TIME
+    ICON_TEMPERATURE = IconConstants.TEMPERATURE
+    ICON_WIND = IconConstants.WIND
+    ICON_HUMIDITY = IconConstants.HUMIDITY
+    ICON_SUCCESS = IconConstants.SUCCESS
+    ICON_ERROR = IconConstants.ERROR
+    ICON_WARNING = IconConstants.WARNING
+    ICON_INFO = IconConstants.INFO

--- a/app_constants.py
+++ b/app_constants.py
@@ -1,0 +1,32 @@
+"""天気コメント生成システム - UI定数定義"""
+
+
+class UIConstants:
+    """UI関連の定数定義"""
+
+    # プログレス関連
+    PROGRESS_COMPLETE_DELAY = 0.5  # プログレス完了後の待機時間（秒）
+    PROGRESS_UPDATE_INTERVAL = 0.1  # プログレス更新間隔（秒）
+
+    # レイアウト関連
+    DEFAULT_COLUMN_RATIO = [1, 2]  # デフォルトのカラム比率
+    SIDEBAR_MIN_WIDTH = 300  # サイドバー最小幅（ピクセル）
+
+    # 表示関連
+    MAX_DISPLAY_HISTORY = 10  # 履歴表示の最大数
+    COMMENT_PREVIEW_LENGTH = 100  # コメントプレビューの最大文字数
+
+    # エラー表示
+    ERROR_DISPLAY_DURATION = 5  # エラー表示時間（秒）
+
+    # アイコン
+    ICON_WEATHER = "🌤️"
+    ICON_LOCATION = "📍"
+    ICON_TIME = "⏰"
+    ICON_TEMPERATURE = "🌡️"
+    ICON_WIND = "💨"
+    ICON_HUMIDITY = "💧"
+    ICON_SUCCESS = "✅"
+    ICON_ERROR = "❌"
+    ICON_WARNING = "⚠️"
+    ICON_INFO = "ℹ️"

--- a/app_controller.py
+++ b/app_controller.py
@@ -1,0 +1,188 @@
+"""天気コメント生成システム - コントローラー（ビジネスロジック）"""
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import pytz
+
+from src.config.app_config import get_config
+from src.types import BatchGenerationResult, LocationResult
+from src.ui.streamlit_utils import load_history, load_locations, save_to_history
+from src.utils.error_handler import ErrorHandler
+from src.workflows.comment_generation_workflow import run_comment_generation
+
+logger = logging.getLogger(__name__)
+
+
+class CommentGenerationController:
+    """コメント生成のビジネスロジックを管理するコントローラー"""
+
+    def __init__(self):
+        self.config = get_config()
+        self._generation_history = None
+
+    @property
+    def generation_history(self) -> list[dict[str, Any]]:
+        """生成履歴を取得（遅延読み込み）"""
+        if self._generation_history is None:
+            self._generation_history = load_history()
+        return self._generation_history
+
+    def get_default_locations(self) -> list[str]:
+        """デフォルトの地点リストを取得"""
+        return load_locations()
+
+    def get_default_llm_provider(self) -> str:
+        """デフォルトのLLMプロバイダーを取得"""
+        return self.config.ui_settings.default_llm_provider
+
+    def validate_configuration(self) -> dict[str, Any]:
+        """設定の検証"""
+        return self.config.validate()
+
+    def get_config_dict(self) -> dict[str, Any]:
+        """設定を辞書形式で取得"""
+        return self.config.to_dict()
+
+    def generate_comment_for_location(self, location: str, llm_provider: str) -> LocationResult:
+        """単一地点のコメント生成"""
+        try:
+            # 実際のコメント生成
+            result = run_comment_generation(
+                location_name=location,
+                target_datetime=datetime.now(),
+                llm_provider=llm_provider
+            )
+
+            # 結果を収集
+            location_result = {
+                'location': location,
+                'result': result,
+                'success': result.get('success', False),
+                'comment': result.get('final_comment', ''),
+                'error': result.get('error', None)
+            }
+
+            # ソースファイル情報を抽出
+            metadata = result.get('generation_metadata', {})
+            if metadata.get('selected_past_comments'):
+                sources = []
+                for comment in metadata['selected_past_comments']:
+                    if 'source_file' in comment:
+                        sources.append(comment['source_file'])
+                if sources:
+                    location_result['source_files'] = sources
+                    # 詳細ログ出力
+                    logger.info(f"地点: {location}")
+                    logger.info(f"  天気: {metadata.get('weather_condition', '不明')}")
+                    logger.info(f"  気温: {metadata.get('temperature', '不明')}°C")
+                    logger.info(f"  コメント生成元ファイル: {sources}")
+                    logger.info(f"  生成コメント: {result.get('final_comment', '')}")
+
+            # 履歴に保存
+            if result.get('success'):
+                save_to_history(result, location, llm_provider)
+                # 履歴キャッシュをクリア
+                self._generation_history = None
+
+            return location_result
+
+        except Exception as e:
+            # エラーハンドリング
+            return ErrorHandler.create_error_result(location, e)
+
+    def generate_comments_batch(self, locations: list[str], llm_provider: str,
+                                progress_callback=None) -> BatchGenerationResult:
+        """複数地点のコメント生成"""
+        if not locations:
+            return {'success': False, 'error': '地点が選択されていません'}
+
+        all_results = []
+        total_locations = len(locations)
+
+        try:
+            for idx, location in enumerate(locations):
+                # 進捗コールバック
+                if progress_callback:
+                    progress_callback(idx, total_locations, location)
+
+                # 個別地点の生成
+                location_result = self.generate_comment_for_location(location, llm_provider)
+                all_results.append(location_result)
+
+            # 成功数をカウント
+            success_count = sum(1 for r in all_results if r['success'])
+
+            # エラーがあった場合は詳細を収集
+            errors = [r for r in all_results if not r['success']]
+            error_messages = []
+
+            for err in errors:
+                location = err['location']
+                error_msg = err.get('error', '不明なエラー')
+                error_messages.append(f"{location}: {error_msg}")
+
+            return {
+                'success': success_count > 0,
+                'total_locations': total_locations,
+                'success_count': success_count,
+                'results': all_results,
+                'final_comment': '\n'.join([f"{r['location']}: {r['comment']}" for r in all_results if r['success']]),
+                'errors': error_messages
+            }
+
+        except Exception as e:
+            # 統一されたエラーハンドリング
+            error_response = ErrorHandler.handle_error(e)
+            return {
+                'success': False,
+                'error': error_response.error_message,
+                'final_comment': None,
+                'hint': error_response.hint
+            }
+
+    def format_forecast_time(self, forecast_time: str) -> str:
+        """予報時刻をフォーマット"""
+        try:
+            # UTC時刻をパース
+            dt = datetime.fromisoformat(forecast_time.replace('Z', '+00:00'))
+            # JSTに変換
+            jst = pytz.timezone('Asia/Tokyo')
+            dt_jst = dt.astimezone(jst)
+            return dt_jst.strftime('%Y年%m月%d日 %H時')
+        except Exception as e:
+            logger.warning(f"予報時刻のパース失敗: {e}, forecast_time={forecast_time}")
+            return forecast_time
+
+    def extract_weather_metadata(self, result: LocationResult) -> dict[str, Any]:
+        """結果から天気メタデータを抽出"""
+        metadata = {}
+
+        if result.get('result') and result['result'].get('generation_metadata'):
+            gen_metadata = result['result']['generation_metadata']
+
+            # 基本情報
+            metadata['forecast_time'] = gen_metadata.get('weather_forecast_time')
+            metadata['temperature'] = gen_metadata.get('temperature')
+            metadata['weather_condition'] = gen_metadata.get('weather_condition')
+            metadata['wind_speed'] = gen_metadata.get('wind_speed')
+            metadata['humidity'] = gen_metadata.get('humidity')
+
+            # 選択されたコメント情報
+            selection_meta = gen_metadata.get('selection_metadata', {})
+            if selection_meta:
+                metadata['selected_weather_comment'] = selection_meta.get('selected_weather_comment')
+                metadata['selected_advice_comment'] = selection_meta.get('selected_advice_comment')
+                metadata['llm_provider'] = selection_meta.get('llm_provider')
+
+        return metadata
+
+    def validate_location_count(self, locations: list[str]) -> tuple[bool, str | None]:
+        """地点数の検証"""
+        max_locations = self.config.ui_settings.max_locations_per_generation
+
+        if len(locations) > max_locations:
+            return False, f"選択された地点数が上限（{max_locations}地点）を超えています。"
+
+        return True, None

--- a/app_interfaces.py
+++ b/app_interfaces.py
@@ -1,0 +1,154 @@
+"""天気コメント生成システム - インターフェース定義"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
+
+from src.types import BatchGenerationResult, LocationResult
+
+
+class ICommentGenerationController(ABC):
+    """コメント生成コントローラーのインターフェース"""
+
+    @property
+    @abstractmethod
+    def generation_history(self) -> list[dict[str, Any]]:
+        """生成履歴を取得"""
+        pass
+
+    @property
+    @abstractmethod
+    def config(self) -> Any:
+        """設定を取得"""
+        pass
+
+    @abstractmethod
+    def get_default_locations(self) -> list[str]:
+        """デフォルトの地点リストを取得"""
+        pass
+
+    @abstractmethod
+    def get_default_llm_provider(self) -> str:
+        """デフォルトのLLMプロバイダーを取得"""
+        pass
+
+    @abstractmethod
+    def validate_configuration(self) -> dict[str, Any]:
+        """設定の検証"""
+        pass
+
+    @abstractmethod
+    def generate_comment_for_location(self, location: str, llm_provider: str) -> LocationResult:
+        """単一地点のコメント生成
+
+        Args:
+            location: 地点名
+            llm_provider: LLMプロバイダー
+
+        Returns:
+            LocationResult: 生成結果
+        """
+        pass
+
+    @abstractmethod
+    def generate_comments_batch(
+        self,
+        locations: list[str],
+        llm_provider: str,
+        progress_callback: Callable[[int, int, str], None] | None = None
+    ) -> BatchGenerationResult:
+        """複数地点のコメント生成
+
+        Args:
+            locations: 地点リスト
+            llm_provider: LLMプロバイダー
+            progress_callback: 進捗通知コールバック
+
+        Returns:
+            BatchGenerationResult: バッチ生成結果
+        """
+        pass
+
+    @abstractmethod
+    def extract_weather_metadata(self, result: LocationResult) -> dict[str, Any]:
+        """天気メタデータの抽出
+
+        Args:
+            result: 地点結果
+
+        Returns:
+            dict: メタデータ
+        """
+        pass
+
+    @abstractmethod
+    def format_forecast_time(self, forecast_time: str) -> str:
+        """予報時刻のフォーマット
+
+        Args:
+            forecast_time: UTC時刻文字列
+
+        Returns:
+            str: フォーマット済み時刻
+        """
+        pass
+
+    @abstractmethod
+    def validate_location_count(self, locations: list[str]) -> tuple[bool, str | None]:
+        """地点数の検証
+
+        Args:
+            locations: 地点リスト
+
+        Returns:
+            tuple: (検証結果, エラーメッセージ)
+        """
+        pass
+
+
+class ICommentGenerationView(ABC):
+    """コメント生成ビューのインターフェース"""
+
+    @abstractmethod
+    def create_progress_ui(self) -> tuple[Any, Any]:
+        """プログレスUIの作成
+
+        Returns:
+            tuple: (progress_bar, status_text)
+        """
+        pass
+
+    @abstractmethod
+    def update_progress(self, progress_bar: Any, status_text: Any, idx: int, total: int, location: str) -> None:
+        """プログレスの更新
+
+        Args:
+            progress_bar: プログレスバーオブジェクト
+            status_text: ステータステキストオブジェクト
+            idx: 現在のインデックス
+            total: 全体数
+            location: 現在の地点名
+        """
+        pass
+
+    @abstractmethod
+    def complete_progress(self, progress_bar: Any, status_text: Any, success_count: int, total: int) -> None:
+        """プログレスの完了処理
+
+        Args:
+            progress_bar: プログレスバーオブジェクト
+            status_text: ステータステキストオブジェクト
+            success_count: 成功数
+            total: 全体数
+        """
+        pass
+
+    @abstractmethod
+    def display_single_result(self, result: LocationResult, metadata: dict[str, Any]) -> None:
+        """単一結果の表示
+
+        Args:
+            result: 地点結果
+            metadata: メタデータ
+        """
+        pass

--- a/app_session_manager.py
+++ b/app_session_manager.py
@@ -1,10 +1,12 @@
 """天気コメント生成システム - セッション管理"""
 
-from typing import Any
+from typing import Any, TypeVar, overload
 
 import streamlit as st
 
 from app_interfaces import ICommentGenerationController
+
+T = TypeVar('T')
 
 
 class SessionManager:
@@ -33,6 +35,18 @@ class SessionManager:
             if key not in st.session_state:
                 st.session_state[key] = value
 
+    @overload
+    @staticmethod
+    def get(key: str) -> Any:
+        """セッション状態から値を取得"""
+        ...
+    
+    @overload
+    @staticmethod
+    def get(key: str, default: T) -> T:
+        """セッション状態から値を取得（デフォルト値付き）"""
+        ...
+    
     @staticmethod
     def get(key: str, default: Any = None) -> Any:
         """セッション状態から値を取得
@@ -42,7 +56,7 @@ class SessionManager:
             default: デフォルト値
 
         Returns:
-            Any: セッション状態の値
+            セッション状態の値またはデフォルト値
         """
         return st.session_state.get(key, default)
 

--- a/app_session_manager.py
+++ b/app_session_manager.py
@@ -1,0 +1,139 @@
+"""天気コメント生成システム - セッション管理"""
+
+from typing import Any
+
+import streamlit as st
+
+from app_interfaces import ICommentGenerationController
+
+
+class SessionManager:
+    """Streamlitセッション状態の管理クラス
+
+    セッション状態の初期化、取得、更新を一元管理します。
+    """
+
+    @staticmethod
+    def initialize(controller: ICommentGenerationController) -> None:
+        """セッション状態の初期化
+
+        Args:
+            controller: コメント生成コントローラー
+        """
+        defaults = {
+            'generation_history': controller.generation_history,
+            'selected_location': controller.get_default_locations(),
+            'llm_provider': controller.get_default_llm_provider(),
+            'current_result': None,
+            'is_generating': False,
+            'config': controller.config
+        }
+
+        for key, value in defaults.items():
+            if key not in st.session_state:
+                st.session_state[key] = value
+
+    @staticmethod
+    def get(key: str, default: Any = None) -> Any:
+        """セッション状態から値を取得
+
+        Args:
+            key: 取得するキー
+            default: デフォルト値
+
+        Returns:
+            Any: セッション状態の値
+        """
+        return st.session_state.get(key, default)
+
+    @staticmethod
+    def set(key: str, value: Any) -> None:
+        """セッション状態に値を設定
+
+        Args:
+            key: 設定するキー
+            value: 設定する値
+        """
+        st.session_state[key] = value
+
+    @staticmethod
+    def update(updates: dict[str, Any]) -> None:
+        """セッション状態を一括更新
+
+        Args:
+            updates: 更新する値の辞書
+        """
+        for key, value in updates.items():
+            st.session_state[key] = value
+
+    @staticmethod
+    def is_generating() -> bool:
+        """生成中かどうかを取得
+
+        Returns:
+            bool: 生成中の場合True
+        """
+        return st.session_state.get('is_generating', False)
+
+    @staticmethod
+    def set_generating(value: bool) -> None:
+        """生成中フラグを設定
+
+        Args:
+            value: 生成中フラグ
+        """
+        st.session_state.is_generating = value
+
+    @staticmethod
+    def get_current_result() -> dict[str, Any] | None:
+        """現在の生成結果を取得
+
+        Returns:
+            Optional[dict]: 生成結果
+        """
+        return st.session_state.get('current_result')
+
+    @staticmethod
+    def set_current_result(result: dict[str, Any] | None) -> None:
+        """現在の生成結果を設定
+
+        Args:
+            result: 生成結果
+        """
+        st.session_state.current_result = result
+
+    @staticmethod
+    def get_selected_location() -> list[str]:
+        """選択された地点を取得
+
+        Returns:
+            list[str]: 地点リスト
+        """
+        return st.session_state.get('selected_location', [])
+
+    @staticmethod
+    def set_selected_location(locations: list[str]) -> None:
+        """選択された地点を設定
+
+        Args:
+            locations: 地点リスト
+        """
+        st.session_state.selected_location = locations
+
+    @staticmethod
+    def get_llm_provider() -> str:
+        """LLMプロバイダーを取得
+
+        Returns:
+            str: LLMプロバイダー名
+        """
+        return st.session_state.get('llm_provider', '')
+
+    @staticmethod
+    def set_llm_provider(provider: str) -> None:
+        """LLMプロバイダーを設定
+
+        Args:
+            provider: LLMプロバイダー名
+        """
+        st.session_state.llm_provider = provider

--- a/app_view.py
+++ b/app_view.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import streamlit as st
 
+from app_constants import UIConstants
+from app_interfaces import ICommentGenerationView
 from src.types import BatchGenerationResult, LocationResult
 from src.ui.streamlit_components import (
     generation_history_display,
@@ -17,8 +19,19 @@ from src.ui.streamlit_components import (
 from src.ui.streamlit_utils import format_timestamp
 
 
-class CommentGenerationView:
-    """UIの表示を管理するビュークラス"""
+class CommentGenerationView(ICommentGenerationView):
+    """UIの表示を管理するビュークラス
+
+    Streamlitを使用したユーザーインターフェースの表示と管理を担当します。
+    MVCパターンのViewレイヤーとして、ビジネスロジックから分離されたUI処理を実装します。
+
+    主な責務:
+    - ページレイアウトの構築
+    - ユーザー入力の収集
+    - 生成結果の表示
+    - プログレス表示
+    - エラーメッセージの表示
+    """
 
     @staticmethod
     def setup_page_config(config):
@@ -65,7 +78,7 @@ class CommentGenerationView:
     @staticmethod
     def display_input_panel() -> tuple[list[str], str]:
         """入力パネルの表示"""
-        st.header("📍 入力設定")
+        st.header(f"{UIConstants.ICON_LOCATION} 入力設定")
 
         # 地点選択
         location = location_selector()
@@ -107,21 +120,21 @@ class CommentGenerationView:
         error = result.get('error', '')
 
         if success:
-            st.success(f"✅ **{location}**: {comment}")
+            st.success(f"{UIConstants.ICON_SUCCESS} **{location}**: {comment}")
 
             # メタデータがある場合は天気情報も表示
             if metadata:
                 with st.expander(f"📊 {location}の詳細情報"):
                     # 予報時刻の表示
                     if metadata.get('forecast_time'):
-                        st.info(f"⏰ 予報時刻: {metadata['forecast_time']}")
+                        st.info(f"{UIConstants.ICON_TIME} 予報時刻: {metadata['forecast_time']}")
 
                     # 天気データの表示
                     col1, col2 = st.columns(2)
                     with col1:
                         temp = metadata.get('temperature')
                         if temp is not None:
-                            st.text(f"🌡️ 気温: {temp}°C")
+                            st.text(f"{UIConstants.ICON_TEMPERATURE} 気温: {temp}°C")
 
                         weather = metadata.get('weather_condition')
                         if weather and weather != '不明':
@@ -130,11 +143,11 @@ class CommentGenerationView:
                     with col2:
                         wind = metadata.get('wind_speed')
                         if wind is not None:
-                            st.text(f"💨 風速: {wind}m/s")
+                            st.text(f"{UIConstants.ICON_WIND} 風速: {wind}m/s")
 
                         humidity = metadata.get('humidity')
                         if humidity is not None:
-                            st.text(f"💧 湿度: {humidity}%")
+                            st.text(f"{UIConstants.ICON_HUMIDITY} 湿度: {humidity}%")
 
                     # 選択されたコメントペア
                     if any(k in metadata for k in ['selected_weather_comment', 'selected_advice_comment']):
@@ -153,7 +166,7 @@ class CommentGenerationView:
                         if provider:
                             st.text(f"選択方法: LLM ({provider})")
         else:
-            st.error(f"❌ **{location}**: {error}")
+            st.error(f"{UIConstants.ICON_ERROR} **{location}**: {error}")
 
     @staticmethod
     def create_progress_ui():
@@ -179,7 +192,7 @@ class CommentGenerationView:
         else:
             status_text.text("エラー：すべての地点でコメント生成に失敗しました")
 
-        time.sleep(0.5)
+        time.sleep(UIConstants.PROGRESS_COMPLETE_DELAY)
         progress_bar.empty()
         status_text.empty()
 
@@ -187,13 +200,13 @@ class CommentGenerationView:
     def display_generation_complete(result: BatchGenerationResult):
         """生成完了時の表示"""
         if result and result['success']:
-            st.success(f"✅ コメント生成が完了しました！ ({result['success_count']}/{result['total_locations']}地点成功)")
+            st.success(f"{UIConstants.ICON_SUCCESS} コメント生成が完了しました！ ({result['success_count']}/{result['total_locations']}地点成功)")
             if result['success_count'] == result['total_locations']:
                 st.balloons()
 
             # 一部失敗した場合のエラー表示
             if result.get('errors'):
-                with st.expander("⚠️ エラー詳細"):
+                with st.expander(f"{UIConstants.ICON_WARNING} エラー詳細"):
                     for error in result['errors']:
                         st.warning(error)
         elif result:
@@ -205,7 +218,7 @@ class CommentGenerationView:
     @staticmethod
     def display_results_section(current_result: BatchGenerationResult | None, is_generating: bool):
         """結果セクションの表示"""
-        st.header("💬 生成結果")
+        st.header(f"{UIConstants.ICON_WEATHER} 生成結果")
 
         # 生成中でない場合のみ固定の結果を表示
         if not is_generating:
@@ -217,9 +230,9 @@ class CommentGenerationView:
             # サンプル表示
             with st.expander("サンプルコメント"):
                 st.markdown("""
-                **晴れの日**: 爽やかな朝ですね  
-                **雨の日**: 傘をお忘れなく  
-                **曇りの日**: 過ごしやすい一日です  
+                **晴れの日**: 爽やかな朝ですね
+                **雨の日**: 傘をお忘れなく
+                **曇りの日**: 過ごしやすい一日です
                 **雪の日**: 足元にお気をつけて
                 """)
 

--- a/app_view.py
+++ b/app_view.py
@@ -1,0 +1,243 @@
+"""天気コメント生成システム - ビュー（UI定義）"""
+
+import time
+from datetime import datetime
+from typing import Any
+
+import streamlit as st
+
+from src.types import BatchGenerationResult, LocationResult
+from src.ui.streamlit_components import (
+    generation_history_display,
+    llm_provider_selector,
+    location_selector,
+    result_display,
+    settings_panel,
+)
+from src.ui.streamlit_utils import format_timestamp
+
+
+class CommentGenerationView:
+    """UIの表示を管理するビュークラス"""
+
+    @staticmethod
+    def setup_page_config(config):
+        """ページ設定"""
+        st.set_page_config(
+            page_title=config.ui_settings.page_title,
+            page_icon=config.ui_settings.page_icon,
+            layout=config.ui_settings.layout,
+            initial_sidebar_state=config.ui_settings.sidebar_state
+        )
+
+    @staticmethod
+    def display_header():
+        """ヘッダー表示"""
+        st.markdown('<h1 class="main-header">☀️ 天気コメント生成システム ☀️</h1>', unsafe_allow_html=True)
+
+    @staticmethod
+    def display_api_key_warning(validation_results: dict[str, Any]):
+        """APIキーの警告表示"""
+        if not validation_results["api_keys"]["wxtech"]:
+            st.error("⚠️ WXTECH_API_KEYが設定されていません。天気予報データの取得ができません。")
+
+    @staticmethod
+    def display_debug_info(config):
+        """デバッグ情報表示"""
+        if config.debug and config.ui_settings.show_debug_info:
+            with st.expander("デバッグ情報", expanded=False):
+                st.json(config.to_dict())
+
+    @staticmethod
+    def setup_sidebar(generation_history: list[dict[str, Any]]):
+        """サイドバーのセットアップ"""
+        with st.sidebar:
+            st.header("設定")
+
+            # APIキー設定
+            with st.expander("APIキー設定", expanded=False):
+                settings_panel()
+
+            # 生成履歴
+            st.header("生成履歴")
+            generation_history_display(generation_history)
+
+    @staticmethod
+    def display_input_panel() -> tuple[list[str], str]:
+        """入力パネルの表示"""
+        st.header("📍 入力設定")
+
+        # 地点選択
+        location = location_selector()
+
+        # LLMプロバイダー選択
+        llm_provider = llm_provider_selector()
+
+        # 現在時刻表示
+        st.info(f"🕐 生成時刻: {format_timestamp(datetime.now())}")
+
+        return location, llm_provider
+
+    @staticmethod
+    def display_generation_button(is_generating: bool) -> bool:
+        """生成ボタンの表示"""
+        return st.button(
+            "🎯 コメント生成",
+            type="primary",
+            disabled=is_generating,
+            use_container_width=True
+        )
+
+    @staticmethod
+    def display_location_warning(max_locations: int):
+        """地点数超過の警告"""
+        st.warning(f"⚠️ 選択された地点数が上限（{max_locations}地点）を超えています。")
+
+    @staticmethod
+    def display_no_location_error():
+        """地点未選択エラー"""
+        st.error("地点が選択されていません")
+
+    @staticmethod
+    def display_single_result(result: LocationResult, metadata: dict[str, Any]):
+        """個別の結果を表示"""
+        location = result['location']
+        success = result['success']
+        comment = result.get('comment', '')
+        error = result.get('error', '')
+
+        if success:
+            st.success(f"✅ **{location}**: {comment}")
+
+            # メタデータがある場合は天気情報も表示
+            if metadata:
+                with st.expander(f"📊 {location}の詳細情報"):
+                    # 予報時刻の表示
+                    if metadata.get('forecast_time'):
+                        st.info(f"⏰ 予報時刻: {metadata['forecast_time']}")
+
+                    # 天気データの表示
+                    col1, col2 = st.columns(2)
+                    with col1:
+                        temp = metadata.get('temperature')
+                        if temp is not None:
+                            st.text(f"🌡️ 気温: {temp}°C")
+
+                        weather = metadata.get('weather_condition')
+                        if weather and weather != '不明':
+                            st.text(f"☁️ 天気: {weather}")
+
+                    with col2:
+                        wind = metadata.get('wind_speed')
+                        if wind is not None:
+                            st.text(f"💨 風速: {wind}m/s")
+
+                        humidity = metadata.get('humidity')
+                        if humidity is not None:
+                            st.text(f"💧 湿度: {humidity}%")
+
+                    # 選択されたコメントペア
+                    if any(k in metadata for k in ['selected_weather_comment', 'selected_advice_comment']):
+                        st.markdown("**🎯 選択されたコメント:**")
+
+                        weather_comment = metadata.get('selected_weather_comment')
+                        advice_comment = metadata.get('selected_advice_comment')
+
+                        if weather_comment:
+                            st.text(f"天気: {weather_comment}")
+                        if advice_comment:
+                            st.text(f"アドバイス: {advice_comment}")
+
+                        # LLMプロバイダー情報
+                        provider = metadata.get('llm_provider')
+                        if provider:
+                            st.text(f"選択方法: LLM ({provider})")
+        else:
+            st.error(f"❌ **{location}**: {error}")
+
+    @staticmethod
+    def create_progress_ui():
+        """プログレスバーとステータステキストを作成"""
+        progress_bar = st.progress(0)
+        status_text = st.empty()
+        return progress_bar, status_text
+
+    @staticmethod
+    def update_progress(progress_bar, status_text, current: int, total: int, location: str):
+        """進捗状況を更新"""
+        progress = current / total
+        progress_bar.progress(progress)
+        status_text.text(f"生成中... {location} ({current + 1}/{total})")
+
+    @staticmethod
+    def complete_progress(progress_bar, status_text, success_count: int, total_count: int):
+        """進捗完了時の表示"""
+        progress_bar.progress(1.0)
+
+        if success_count > 0:
+            status_text.text(f"完了！{success_count}/{total_count}地点の生成が成功しました")
+        else:
+            status_text.text("エラー：すべての地点でコメント生成に失敗しました")
+
+        time.sleep(0.5)
+        progress_bar.empty()
+        status_text.empty()
+
+    @staticmethod
+    def display_generation_complete(result: BatchGenerationResult):
+        """生成完了時の表示"""
+        if result and result['success']:
+            st.success(f"✅ コメント生成が完了しました！ ({result['success_count']}/{result['total_locations']}地点成功)")
+            if result['success_count'] == result['total_locations']:
+                st.balloons()
+
+            # 一部失敗した場合のエラー表示
+            if result.get('errors'):
+                with st.expander("⚠️ エラー詳細"):
+                    for error in result['errors']:
+                        st.warning(error)
+        elif result:
+            # すべて失敗した場合
+            if result.get('errors'):
+                for error in result['errors']:
+                    st.error(error)
+
+    @staticmethod
+    def display_results_section(current_result: BatchGenerationResult | None, is_generating: bool):
+        """結果セクションの表示"""
+        st.header("💬 生成結果")
+
+        # 生成中でない場合のみ固定の結果を表示
+        if not is_generating:
+            if current_result:
+                result_display(current_result)
+            else:
+                st.info("👈 左側のパネルから地点とLLMプロバイダーを選択して、「コメント生成」ボタンをクリックしてください。")
+
+            # サンプル表示
+            with st.expander("サンプルコメント"):
+                st.markdown("""
+                **晴れの日**: 爽やかな朝ですね  
+                **雨の日**: 傘をお忘れなく  
+                **曇りの日**: 過ごしやすい一日です  
+                **雪の日**: 足元にお気をつけて
+                """)
+
+    @staticmethod
+    def display_footer():
+        """フッター表示"""
+        st.markdown("---")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            st.markdown("**Version**: 1.0.0")
+        with col2:
+            st.markdown("**Last Updated**: 2025-06-06")
+        with col3:
+            st.markdown("**By**: WNI Team")
+
+    @staticmethod
+    def display_error_with_hint(error_message: str, hint: str | None = None):
+        """エラーメッセージとヒントの表示"""
+        st.error(error_message)
+        if hint:
+            st.info(f"💡 ヒント: {hint}")


### PR DESCRIPTION
## Summary
- app.pyのUIとビジネスロジックを分離し、MVCパターンを適用
- 機能の変更なしに、コードの責務を明確化

## 変更内容
### app_controller.py（新規）
- コメント生成のビジネスロジックを管理
- 設定の検証と管理
- 生成履歴の管理
- エラーハンドリング

### app_view.py（新規）
- Streamlit UIコンポーネントの定義
- 表示ロジックの集約
- UIヘルパー関数

### app.py（更新）
- エントリーポイントのみに簡略化（392行→175行）
- コントローラーとビューの連携
- メイン処理フローの定義

## Test plan
- [x] Ruffによるコード品質チェック完了
- [x] 既存のテストが通ることを確認
- [ ] 手動でアプリケーションの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)