### PR TITLE
fix: 天気データの不整合問題を修正

### DIFF
--- a/src/formatters/weather_timeline_formatter.py
+++ b/src/formatters/weather_timeline_formatter.py
@@ -129,8 +129,13 @@ class WeatherTimelineFormatter:
                 weather_type = classify_weather_type(condition)
                 weather_type_sequence.append(weather_type or "other")
             
+            # デバッグログ
+            logger.debug(f"天気条件: {weather_conditions}")
+            logger.debug(f"天気タイプ: {weather_type_sequence}")
+            
             # タイプレベルでの変化回数をカウント
             type_changes = count_weather_type_changes(weather_type_sequence)
+            logger.debug(f"タイプ変化回数: {type_changes}")
             
             # 判定ロジック
             # WEATHER_CHANGE_THRESHOLD回以上タイプが変わる場合は変わりやすい

--- a/src/nodes/weather_forecast/data_validator.py
+++ b/src/nodes/weather_forecast/data_validator.py
@@ -15,6 +15,35 @@ logger = logging.getLogger(__name__)
 class WeatherDataValidator:
     """天気予報データ検証・選択クラス"""
     
+    def select_forecast_by_time(self, forecasts: List[WeatherForecast], target_datetime) -> WeatherForecast:
+        """指定された時刻に最も近い予報データを選択
+        
+        Args:
+            forecasts: 予報データリスト
+            target_datetime: ターゲット時刻
+            
+        Returns:
+            ターゲット時刻に最も近い予報データ
+        """
+        if not forecasts:
+            error_msg = "指定時刻の天気予報データが取得できませんでした"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+        
+        # ターゲット時刻に最も近い予報を選択
+        closest_forecast = min(
+            forecasts, 
+            key=lambda f: abs((f.datetime - target_datetime).total_seconds())
+        )
+        
+        logger.info(
+            f"指定時刻 {target_datetime.strftime('%H:%M')} に最も近い予報を選択: "
+            f"{closest_forecast.datetime.strftime('%H:%M')}, {closest_forecast.weather_description}, "
+            f"{closest_forecast.temperature}°C"
+        )
+        
+        return closest_forecast
+    
     def select_priority_forecast(self, forecasts: List[WeatherForecast]) -> WeatherForecast:
         """翌日9:00-18:00の予報から最も重要な気象条件を選択
         

--- a/src/nodes/weather_forecast_node.py
+++ b/src/nodes/weather_forecast_node.py
@@ -364,9 +364,9 @@ def fetch_weather_forecast_node(state):
             if closest_forecast:
                 period_forecasts.append(closest_forecast)
         
-        # 期間内の予報から最も重要な天気条件を選択
+        # ターゲット時刻に最も近い予報を選択
         validator = WeatherDataValidator()
-        selected_forecast = validator.select_priority_forecast(period_forecasts)
+        selected_forecast = validator.select_forecast_by_time(period_forecasts, target_datetime)
         
         # 気象変化傾向の分析
         if len(period_forecasts) >= 2:

--- a/tests/test_weather_data_selection.py
+++ b/tests/test_weather_data_selection.py
@@ -1,0 +1,105 @@
+"""天気データ選択ロジックのテスト"""
+
+import pytest
+from datetime import datetime, timedelta
+import pytz
+from src.data.weather_data import WeatherForecast, WeatherCondition
+from src.nodes.weather_forecast.data_validator import WeatherDataValidator
+
+
+class TestWeatherDataSelection:
+    """天気データ選択のテストクラス"""
+    
+    def setup_method(self):
+        """テストのセットアップ"""
+        self.validator = WeatherDataValidator()
+        self.jst = pytz.timezone('Asia/Tokyo')
+        self.base_time = self.jst.localize(datetime(2025, 7, 7, 15, 0))  # 15:00 JST
+    
+    def create_forecast(self, hour: int, temp: float, weather: str, condition: WeatherCondition) -> WeatherForecast:
+        """テスト用の予報データを作成"""
+        from src.data.weather_data import WindDirection
+        
+        dt = self.jst.localize(datetime(2025, 7, 7, hour, 0))
+        return WeatherForecast(
+            location="テスト地点",
+            datetime=dt,
+            temperature=temp,
+            weather_code="test",
+            weather_condition=condition,
+            weather_description=weather,
+            precipitation=0.0,
+            humidity=70,
+            wind_speed=2.0,
+            wind_direction=WindDirection.N,
+            wind_direction_degrees=0
+        )
+    
+    def test_select_forecast_by_time_exact_match(self):
+        """指定時刻と完全一致する予報の選択"""
+        forecasts = [
+            self.create_forecast(9, 29.0, "うすぐもり", WeatherCondition.CLOUDY),
+            self.create_forecast(12, 33.0, "くもり", WeatherCondition.CLOUDY),
+            self.create_forecast(15, 34.0, "くもり", WeatherCondition.CLOUDY),  # ターゲット
+            self.create_forecast(18, 30.0, "くもり", WeatherCondition.CLOUDY),
+        ]
+        
+        selected = self.validator.select_forecast_by_time(forecasts, self.base_time)
+        
+        assert selected.datetime.hour == 15
+        assert selected.temperature == 34.0
+        assert selected.weather_description == "くもり"
+    
+    def test_select_forecast_by_time_closest(self):
+        """最も近い時刻の予報を選択"""
+        target_time = self.jst.localize(datetime(2025, 7, 7, 14, 0))  # 14:00
+        
+        forecasts = [
+            self.create_forecast(9, 29.0, "うすぐもり", WeatherCondition.CLOUDY),
+            self.create_forecast(12, 33.0, "くもり", WeatherCondition.CLOUDY),
+            self.create_forecast(15, 34.0, "くもり", WeatherCondition.CLOUDY),  # 最も近い
+            self.create_forecast(18, 30.0, "くもり", WeatherCondition.CLOUDY),
+        ]
+        
+        selected = self.validator.select_forecast_by_time(forecasts, target_time)
+        
+        assert selected.datetime.hour == 15  # 14:00に最も近いのは15:00
+        assert selected.temperature == 34.0
+    
+    def test_select_forecast_by_time_with_extreme_heat(self):
+        """猛暑日でも指定時刻のデータを選択"""
+        forecasts = [
+            self.create_forecast(9, 29.0, "晴れ", WeatherCondition.CLEAR),
+            self.create_forecast(12, 35.0, "晴れ", WeatherCondition.EXTREME_HEAT),  # 猛暑
+            self.create_forecast(15, 34.0, "くもり", WeatherCondition.CLOUDY),  # ターゲット
+            self.create_forecast(18, 30.0, "くもり", WeatherCondition.CLOUDY),
+        ]
+        
+        selected = self.validator.select_forecast_by_time(forecasts, self.base_time)
+        
+        # 35℃の猛暑があっても、15:00が指定されていれば34℃のデータを選択
+        assert selected.datetime.hour == 15
+        assert selected.temperature == 34.0
+        assert selected.weather_description == "くもり"
+    
+    def test_select_priority_forecast_vs_time_based(self):
+        """優先度ベースと時刻ベースの選択の違い"""
+        forecasts = [
+            self.create_forecast(9, 29.0, "晴れ", WeatherCondition.CLEAR),
+            self.create_forecast(12, 35.0, "晴れ", WeatherCondition.EXTREME_HEAT),  # 優先度高
+            self.create_forecast(15, 34.0, "くもり", WeatherCondition.CLOUDY),
+            self.create_forecast(18, 30.0, "小雨", WeatherCondition.RAIN),
+        ]
+        
+        # 優先度ベースの選択
+        priority_selected = self.validator.select_priority_forecast(forecasts)
+        assert priority_selected.temperature == 35.0  # 猛暑が選択される
+        
+        # 時刻ベースの選択
+        time_selected = self.validator.select_forecast_by_time(forecasts, self.base_time)
+        assert time_selected.temperature == 34.0  # 15:00のデータが選択される
+    
+    def test_empty_forecast_list(self):
+        """空の予報リストでエラー"""
+        with pytest.raises(ValueError, match="指定時刻の天気予報データが取得できませんでした"):
+            self.validator.select_forecast_by_time([], self.base_time)


### PR DESCRIPTION
- 予報データ選択ロジックを改善：指定時刻に最も近いデータを選択するように変更
  - WeatherDataValidatorに`select_forecast_by_time`メソッドを追加
  - 優先度ベースの選択から時刻ベースの選択に変更
- 天気パターン判定のデバッグログを追加
- テストケースを追加して動作を検証

修正前: 15:00のデータを要求しても、優先度の高い猛暑（35℃）のデータが選択される
修正後: 15:00に最も近い時刻のデータ（34℃）が正しく選択される
