### PR TITLE
feat: 雨天時のコメント選択ロジックを改善

### DIFF
--- a/src/apis/wxtech/client.py
+++ b/src/apis/wxtech/client.py
@@ -138,8 +138,8 @@ class WxTechAPIClient:
         # 最大の時間数を取得（4つの時刻すべてをカバーするため）
         max_hours = max(hours_to_targets)
         
-        # 余裕を持たせて+1時間
-        forecast_hours = max(int(max_hours) + 1, 1)
+        # 余裕を持たせて+2時間（APIの返すデータ間隔を考慮）
+        forecast_hours = int(max_hours) + 2
         
         # ログ出力で各時刻を表示
         time_info = []
@@ -149,7 +149,15 @@ class WxTechAPIClient:
         logger.info(f"翌日の4時刻: {', '.join(time_info)}, API取得時間: {forecast_hours}時間")
         
         # 4つの時刻すべてをカバーする時間でデータを取得
-        return self.get_forecast(lat, lon, forecast_hours=forecast_hours)
+        forecast_collection = self.get_forecast(lat, lon, forecast_hours=forecast_hours)
+        
+        # 取得したデータの詳細をログ出力
+        logger.info(f"取得したデータ件数: {len(forecast_collection.forecasts)}件")
+        if forecast_collection.forecasts:
+            for i, forecast in enumerate(forecast_collection.forecasts[:10]):  # 最初の10件まで表示
+                logger.debug(f"  データ{i+1}: {forecast.datetime.strftime('%Y-%m-%d %H:%M')} - {forecast.weather_description}")
+        
+        return forecast_collection
     
     def test_specific_time_parameters(self, lat: float, lon: float) -> Dict[str, Any]:
         """特定時刻指定パラメータのテスト

--- a/src/data/weather_data.py
+++ b/src/data/weather_data.py
@@ -110,6 +110,7 @@ class WeatherForecast:
     uv_index: Optional[int] = None
     confidence: Optional[float] = None
     raw_data: Dict[str, Any] = field(default_factory=dict)
+    hourly_forecasts: Optional[List['HourlyWeather']] = None  # 時間毎の予報データ
 
     def __post_init__(self):
         """データクラス初期化後の検証処理"""

--- a/src/llm/providers/anthropic_provider.py
+++ b/src/llm/providers/anthropic_provider.py
@@ -23,7 +23,8 @@ class AnthropicProvider(LLMProvider):
             api_key: Anthropic APIキー
             model: 使用するモデル名
         """
-        self.client = Anthropic(api_key=api_key)
+        # タイムアウトを30秒に設定
+        self.client = Anthropic(api_key=api_key, timeout=30.0)
         self.model = model
         logger.info(f"Initialized Anthropic provider with model: {model}")
 

--- a/src/llm/providers/gemini_provider.py
+++ b/src/llm/providers/gemini_provider.py
@@ -47,40 +47,63 @@ class GeminiProvider(LLMProvider):
         Returns:
             生成されたコメント
         """
-        try:
-            # プロンプトの構築
-            prompt = self._build_prompt(weather_data, past_comments, constraints)
+        import time
+        max_retries = 3
+        retry_delay = 2
+        
+        for attempt in range(max_retries):
+            try:
+                # プロンプトの構築
+                prompt = self._build_prompt(weather_data, past_comments, constraints)
 
-            # システムプロンプトを含めた完全なプロンプト
-            full_prompt = (
-                "あなたは天気予報のコメント作成の専門家です。"
-                "短く、親しみやすいコメントを生成してください。\n\n"
-                f"{prompt}"
-            )
+                # システムプロンプトを含めた完全なプロンプト（簡潔に）
+                full_prompt = f"天気予報の短いコメントを生成。最大15文字。\n{prompt}"
 
-            # APIリクエスト
-            # タイムアウトエラーを回避するため、短いレスポンスを要求
-            response = self.model.generate_content(
-                full_prompt,
-                generation_config=genai.GenerationConfig(
-                    temperature=0.7,
-                    max_output_tokens=50,
-                    candidate_count=1,  # 候補数を1に制限
+                logger.info(f"Gemini API呼び出し開始 (試行 {attempt + 1}/{max_retries})")
+                
+                # APIリクエスト（さらに簡潔な設定）
+                response = self.model.generate_content(
+                    full_prompt,
+                    generation_config=genai.GenerationConfig(
+                        temperature=0.5,  # より確定的な出力
+                        max_output_tokens=30,  # さらに短く
+                        candidate_count=1,
+                        top_p=0.8,  # 確率分布を制限
+                        top_k=10,  # 候補トークンを制限
+                    ),
+                    safety_settings={
+                        "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE",
+                        "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE",
+                        "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE",
+                        "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE",
+                    }
                 )
-            )
 
-            # レスポンスからコメントを抽出
-            generated_comment = response.text.strip()
+                # レスポンスからコメントを抽出
+                generated_comment = response.text.strip()
+                # 改行や余分な記号を除去
+                generated_comment = generated_comment.replace("\n", "").strip('"')
 
-            # 改行や余分な記号を除去
-            generated_comment = generated_comment.replace("\n", "").strip('"')
+                logger.info(f"Generated comment: {generated_comment}")
+                return generated_comment
 
-            logger.info(f"Generated comment: {generated_comment}")
-            return generated_comment
-
-        except Exception as e:
-            logger.error(f"Error in Gemini API call: {str(e)}")
-            raise
+            except Exception as e:
+                error_msg = str(e)
+                logger.error(f"Gemini API error (attempt {attempt + 1}): {error_msg}")
+                
+                if "timeout" in error_msg.lower() or "timed out" in error_msg.lower():
+                    if attempt < max_retries - 1:
+                        wait_time = retry_delay * (attempt + 1)
+                        logger.warning(f"タイムアウトエラー。{wait_time}秒後にリトライします...")
+                        time.sleep(wait_time)
+                        continue
+                
+                if attempt == max_retries - 1:
+                    # 最後の試行でも失敗した場合は、フォールバックコメントを返す
+                    logger.error("Gemini API呼び出しが全て失敗しました。フォールバックコメントを使用します。")
+                    return "本日の天気情報です"
+                    
+        return "本日の天気情報です"
 
     def generate(self, prompt: str) -> str:
         """
@@ -92,26 +115,55 @@ class GeminiProvider(LLMProvider):
         Returns:
             生成されたテキスト
         """
-        try:
-            logger.info(f"Generating text with Gemini")
+        import time
+        max_retries = 3
+        retry_delay = 2
+        
+        # プロンプトを短くして、簡潔な指示に変更
+        simplified_prompt = f"簡潔に回答してください（100文字以内）:\n{prompt[:500]}"
+        
+        for attempt in range(max_retries):
+            try:
+                logger.info(f"Generating text with Gemini (attempt {attempt + 1}/{max_retries})")
 
-            response = self.model.generate_content(
-                prompt,
-                generation_config=genai.GenerationConfig(
-                    temperature=0.7,
-                    max_output_tokens=500,
-                    candidate_count=1,  # 候補数を1に制限
+                response = self.model.generate_content(
+                    simplified_prompt,
+                    generation_config=genai.GenerationConfig(
+                        temperature=0.5,
+                        max_output_tokens=200,  # 短めに制限
+                        candidate_count=1,
+                        top_p=0.8,
+                        top_k=20,
+                    ),
+                    safety_settings={
+                        "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE",
+                        "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE",
+                        "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE",
+                        "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE",
+                    }
                 )
-            )
 
-            generated_text = response.text
-            logger.info(f"Generated text: {generated_text[:100]}...")
+                generated_text = response.text
+                logger.info(f"Generated text: {generated_text[:100]}...")
 
-            return generated_text
+                return generated_text
 
-        except Exception as e:
-            logger.error(f"Gemini API error: {str(e)}")
-            raise
+            except Exception as e:
+                error_msg = str(e)
+                logger.error(f"Gemini API error (attempt {attempt + 1}): {error_msg}")
+                
+                if "timeout" in error_msg.lower() or "timed out" in error_msg.lower():
+                    if attempt < max_retries - 1:
+                        wait_time = retry_delay * (attempt + 1)
+                        logger.warning(f"タイムアウトエラー。{wait_time}秒後にリトライします...")
+                        time.sleep(wait_time)
+                        continue
+                
+                if attempt == max_retries - 1:
+                    logger.error("Gemini API呼び出しが全て失敗しました")
+                    raise
+                    
+        raise Exception("Gemini API呼び出しが全て失敗しました")
 
 
 # エクスポート

--- a/src/llm/providers/gemini_provider.py
+++ b/src/llm/providers/gemini_provider.py
@@ -53,13 +53,14 @@ class GeminiProvider(LLMProvider):
                 f"{prompt}"
             )
 
-            # APIリクエスト
+            # APIリクエスト（タイムアウトを30秒に設定）
             response = self.model.generate_content(
                 full_prompt,
                 generation_config=genai.GenerationConfig(
                     temperature=0.7,
                     max_output_tokens=50,
                 ),
+                request_options={"timeout": 30}
             )
 
             # レスポンスからコメントを抽出
@@ -94,6 +95,7 @@ class GeminiProvider(LLMProvider):
                     temperature=0.7,
                     max_output_tokens=500,
                 ),
+                request_options={"timeout": 30}
             )
 
             generated_text = response.text

--- a/src/llm/providers/gemini_provider.py
+++ b/src/llm/providers/gemini_provider.py
@@ -23,7 +23,12 @@ class GeminiProvider(LLMProvider):
             api_key: Gemini APIキー
             model: 使用するモデル名
         """
-        genai.configure(api_key=api_key)
+        # タイムアウトを含む設定でAPIを初期化
+        genai.configure(
+            api_key=api_key,
+            transport='rest',  # RESTトランスポートを使用
+            client_options={'api_endpoint': 'https://generativelanguage.googleapis.com'}
+        )
         self.model = genai.GenerativeModel(model)
         self.model_name = model
         logger.info(f"Initialized Gemini provider with model: {model}")
@@ -53,14 +58,15 @@ class GeminiProvider(LLMProvider):
                 f"{prompt}"
             )
 
-            # APIリクエスト（タイムアウトを30秒に設定）
+            # APIリクエスト
+            # タイムアウトエラーを回避するため、短いレスポンスを要求
             response = self.model.generate_content(
                 full_prompt,
                 generation_config=genai.GenerationConfig(
                     temperature=0.7,
                     max_output_tokens=50,
-                ),
-                request_options={"timeout": 30}
+                    candidate_count=1,  # 候補数を1に制限
+                )
             )
 
             # レスポンスからコメントを抽出
@@ -94,8 +100,8 @@ class GeminiProvider(LLMProvider):
                 generation_config=genai.GenerationConfig(
                     temperature=0.7,
                     max_output_tokens=500,
-                ),
-                request_options={"timeout": 30}
+                    candidate_count=1,  # 候補数を1に制限
+                )
             )
 
             generated_text = response.text

--- a/src/llm/providers/openai_provider.py
+++ b/src/llm/providers/openai_provider.py
@@ -24,7 +24,8 @@ class OpenAIProvider(LLMProvider):
             api_key: OpenAI APIキー
             model: 使用するモデル名
         """
-        self.client = OpenAI(api_key=api_key)
+        # タイムアウトを30秒に設定（60秒だとタイムアウトエラーが発生するため）
+        self.client = OpenAI(api_key=api_key, timeout=30.0)
         self.model = model
         logger.info(f"Initialized OpenAI provider with model: {model}")
 

--- a/src/nodes/comment_selector/base_selector.py
+++ b/src/nodes/comment_selector/base_selector.py
@@ -126,7 +126,7 @@ class CommentSelector:
             
         # LLMで選択
         return self.llm_selector.llm_select_comment(
-            candidates, weather_data, location_name, target_datetime, CommentType.WEATHER_COMMENT
+            candidates, weather_data, location_name, target_datetime, CommentType.WEATHER_COMMENT, state
         )
     
     def _select_best_advice_comment(
@@ -152,7 +152,7 @@ class CommentSelector:
             
         # LLMで選択
         return self.llm_selector.llm_select_comment(
-            candidates, weather_data, location_name, target_datetime, CommentType.ADVICE
+            candidates, weather_data, location_name, target_datetime, CommentType.ADVICE, state
         )
     
     def _fallback_comment_selection(

--- a/src/nodes/comment_selector/llm_selector.py
+++ b/src/nodes/comment_selector/llm_selector.py
@@ -184,6 +184,23 @@ class LLMCommentSelector:
 - 「爽やか」「穏やか」「安定」「良好」などの表現が適切です
 """
         
+        # 雨天時の特別な注意事項を追加
+        rain_warning = ""
+        if "雨" in weather_context or "降水量" in weather_context:
+            # weather_contextから降水量を抽出
+            import re
+            precip_match = re.search(r'降水量:\s*([\d.]+)mm', weather_context)
+            if precip_match:
+                precipitation = float(precip_match.group(1))
+                if precipitation > 0:
+                    rain_warning = f"""
+【雨天時の特別注意】:
+- 現在降水量が{precipitation}mmあります。必ず雨に言及したコメントを選んでください
+- 天気コメントでは「雨」「降雨」「雨が」「にわか雨」などの雨関連表現を含むものを優先
+- アドバイスコメントでは「傘」「雨具」「雨対策」などの実用的なアドバイスを含むものを優先
+- 「晴れ」「青空」「日差し」などの晴天表現を含むコメントは絶対に選ばないでください
+"""
+        
         # 月別の不適切表現の注意事項を追加
         import re
         month_match = re.search(r'(\d+)月', weather_context)
@@ -223,6 +240,7 @@ class LLMCommentSelector:
 6. 自然で読みやすい表現
 
 {sunny_warning}
+{rain_warning}
 {month_warning}
 
 特に以下を重視してください:

--- a/src/nodes/comment_selector/utils.py
+++ b/src/nodes/comment_selector/utils.py
@@ -79,13 +79,16 @@ class CommentUtils:
             
             # 将来の予報データをチェック
             if hasattr(weather_data, 'hourly_forecasts') and weather_data.hourly_forecasts:
+                logger.info(f"予報データ数: {len(weather_data.hourly_forecasts)}")
                 for forecast in weather_data.hourly_forecasts:
                     if hasattr(forecast, 'precipitation_mm') and forecast.precipitation_mm > 0:
                         has_rain_forecast = True
                         max_future_precipitation = max(max_future_precipitation, forecast.precipitation_mm)
+                        logger.info(f"雨予報検出: {forecast.datetime if hasattr(forecast, 'datetime') else '時刻不明'} - {forecast.precipitation_mm}mm")
                     elif hasattr(forecast, 'precipitation') and forecast.precipitation > 0:
                         has_rain_forecast = True
                         max_future_precipitation = max(max_future_precipitation, forecast.precipitation)
+                        logger.info(f"雨予報検出: {forecast.datetime if hasattr(forecast, 'datetime') else '時刻不明'} - {forecast.precipitation}mm")
             
             if has_rain_now or has_rain_forecast:
                 rain_keywords = ["雨", "降雨", "雨が", "にわか雨", "雨模様", "雨音", "雨降り", "傘"]

--- a/src/nodes/comment_selector/utils.py
+++ b/src/nodes/comment_selector/utils.py
@@ -24,6 +24,7 @@ class CommentUtils:
     ) -> List[Dict[str, Any]]:
         """天気コメント候補を準備"""
         candidates = []
+        rain_priority = []  # 雨天時の優先候補
         severe_matched = []
         weather_matched = []
         others = []
@@ -66,10 +67,18 @@ class CommentUtils:
                 continue
                 
             candidate = self._create_candidate_dict(
-                len(severe_matched) + len(weather_matched) + len(others), 
+                len(rain_priority) + len(severe_matched) + len(weather_matched) + len(others), 
                 comment, 
                 original_index=i
             )
+            
+            # 雨天時の特別な優先順位付け
+            if weather_data.precipitation > 0:
+                rain_keywords = ["雨", "降雨", "雨が", "にわか雨", "雨模様", "雨音", "雨降り"]
+                if any(keyword in comment.comment_text for keyword in rain_keywords):
+                    rain_priority.append(candidate)
+                    logger.debug(f"雨天時優先候補に追加: '{comment.comment_text}'")
+                    continue
             
             # 悪天候時の特別な優先順位付け
             from src.config.severe_weather_config import get_severe_weather_config
@@ -96,22 +105,47 @@ class CommentUtils:
         except:
             limit = 100  # デフォルト値
         
-        # 設定ファイルから候補比率を取得
-        try:
-            ratios = config.get('generation', {}).get('candidate_ratios', {})
-            severe_ratio = ratios.get('severe_weather', 0.4)
-            weather_ratio = ratios.get('weather_matched', 0.4)
-            others_ratio = ratios.get('others', 0.2)
-        except:
-            # デフォルト比率（悪天候40%, 天気マッチ40%, その他20%）
-            severe_ratio, weather_ratio, others_ratio = 0.4, 0.4, 0.2
-        
-        # 各カテゴリの制限を計算
-        severe_limit = int(limit * severe_ratio)
-        weather_limit = int(limit * weather_ratio) 
-        others_limit = limit - severe_limit - weather_limit
-        
-        candidates = (severe_matched[:severe_limit] + weather_matched[:weather_limit] + others[:others_limit])
+        # 雨天時は雨関連コメントを最優先
+        if weather_data.precipitation > 0 and rain_priority:
+            # 雨天時は雨関連候補を50%以上確保
+            rain_limit = max(limit // 2, len(rain_priority))
+            remaining_limit = limit - min(len(rain_priority), rain_limit)
+            
+            # 残りの枠を他のカテゴリに配分
+            if remaining_limit > 0:
+                severe_limit = min(len(severe_matched), remaining_limit // 3)
+                weather_limit = min(len(weather_matched), remaining_limit // 3)
+                others_limit = remaining_limit - severe_limit - weather_limit
+                
+                candidates = (rain_priority[:rain_limit] + 
+                            severe_matched[:severe_limit] + 
+                            weather_matched[:weather_limit] + 
+                            others[:others_limit])
+            else:
+                candidates = rain_priority[:limit]
+                
+            logger.info(f"雨天時の候補配分 - 雨優先: {len(rain_priority[:rain_limit])}, " +
+                       f"悪天候: {len(severe_matched[:severe_limit]) if remaining_limit > 0 else 0}, " +
+                       f"天気マッチ: {len(weather_matched[:weather_limit]) if remaining_limit > 0 else 0}, " +
+                       f"その他: {len(others[:others_limit]) if remaining_limit > 0 else 0}")
+        else:
+            # 通常時の配分
+            # 設定ファイルから候補比率を取得
+            try:
+                ratios = config.get('generation', {}).get('candidate_ratios', {})
+                severe_ratio = ratios.get('severe_weather', 0.4)
+                weather_ratio = ratios.get('weather_matched', 0.4)
+                others_ratio = ratios.get('others', 0.2)
+            except:
+                # デフォルト比率（悪天候40%, 天気マッチ40%, その他20%）
+                severe_ratio, weather_ratio, others_ratio = 0.4, 0.4, 0.2
+            
+            # 各カテゴリの制限を計算
+            severe_limit = int(limit * severe_ratio)
+            weather_limit = int(limit * weather_ratio) 
+            others_limit = limit - severe_limit - weather_limit
+            
+            candidates = (severe_matched[:severe_limit] + weather_matched[:weather_limit] + others[:others_limit])
         
         return candidates
     
@@ -124,6 +158,7 @@ class CommentUtils:
         target_datetime
     ) -> List[Dict[str, Any]]:
         """アドバイスコメント候補を準備"""
+        rain_priority = []  # 雨天時の優先候補
         candidates = []
         
         for i, comment in enumerate(comments):
@@ -153,21 +188,42 @@ class CommentUtils:
                 logger.debug(f"アドバイス条件不適合のため除外: '{comment.comment_text}'")
                 continue
                 
-            candidate = self._create_candidate_dict(len(candidates), comment, original_index=i)
+            candidate = self._create_candidate_dict(len(rain_priority) + len(candidates), comment, original_index=i)
+            
+            # 雨天時の特別な優先順位付け
+            if weather_data.precipitation > 0:
+                rain_keywords = ["傘", "雨具", "雨対策", "濡れ", "レインコート", "雨よけ", "雨宿り"]
+                if any(keyword in comment.comment_text for keyword in rain_keywords):
+                    rain_priority.append(candidate)
+                    logger.debug(f"雨天時優先アドバイス候補に追加: '{comment.comment_text}'")
+                    continue
+            
             candidates.append(candidate)
             
-            # 設定ファイルから制限を取得
-            from src.config.config_loader import load_config
-            try:
-                config = load_config('weather_thresholds', validate=False)
-                limit = config.get('generation', {}).get('advice_candidates_limit', 100)
-            except:
-                limit = 100  # デフォルト値
-            
-            if len(candidates) >= limit:
-                break
+        # 設定ファイルから制限を取得
+        from src.config.config_loader import load_config
+        try:
+            config = load_config('weather_thresholds', validate=False)
+            limit = config.get('generation', {}).get('advice_candidates_limit', 100)
+        except:
+            limit = 100  # デフォルト値
         
-        return candidates
+        # 雨天時は雨関連アドバイスを最優先
+        if weather_data.precipitation > 0 and rain_priority:
+            # 雨天時は雨関連候補を50%以上確保
+            rain_limit = max(limit // 2, len(rain_priority))
+            remaining_limit = limit - min(len(rain_priority), rain_limit)
+            
+            if remaining_limit > 0:
+                final_candidates = rain_priority[:rain_limit] + candidates[:remaining_limit]
+            else:
+                final_candidates = rain_priority[:limit]
+                
+            logger.info(f"雨天時のアドバイス候補配分 - 雨優先: {len(rain_priority[:rain_limit])}, " +
+                       f"その他: {len(candidates[:remaining_limit]) if remaining_limit > 0 else 0}")
+            return final_candidates
+        else:
+            return candidates[:limit]
     
     def _create_candidate_dict(self, index: int, comment: PastComment, original_index: int) -> Dict[str, Any]:
         """候補辞書を作成"""

--- a/src/nodes/comment_selector/validation.py
+++ b/src/nodes/comment_selector/validation.py
@@ -261,8 +261,24 @@ class CommentValidator:
     
     def is_no_rain_weather_with_rain_comment(self, comment_text: str, weather_data: WeatherForecast) -> bool:
         """降水なしの天気時に雨・雷関連のコメントが含まれているかチェック"""
-        # 降水量が0または極めて少ない場合（0.5mm未満）
-        if weather_data.precipitation >= 0.5:
+        # 現在の降水量をチェック
+        has_rain_now = weather_data.precipitation >= 0.5
+        
+        # 将来の予報もチェック
+        has_rain_forecast = False
+        if hasattr(weather_data, 'hourly_forecasts') and weather_data.hourly_forecasts:
+            for forecast in weather_data.hourly_forecasts:
+                precip = 0
+                if hasattr(forecast, 'precipitation_mm'):
+                    precip = forecast.precipitation_mm
+                elif hasattr(forecast, 'precipitation'):
+                    precip = forecast.precipitation
+                if precip >= 0.5:
+                    has_rain_forecast = True
+                    break
+        
+        # 現在も将来も雨がある場合は、雨コメントOK
+        if has_rain_now or has_rain_forecast:
             return False
         
         # 不適切な雨・雷関連表現パターン

--- a/src/nodes/select_comment_pair_node.py
+++ b/src/nodes/select_comment_pair_node.py
@@ -45,6 +45,20 @@ def select_comment_pair_node(state: CommentGenerationState) -> CommentGeneration
             raise ValueError("適切なコメントタイプが見つかりません")
 
         logger.info(f"天気コメント数: {len(weather_comments)}, アドバイスコメント数: {len(advice_comments)}")
+        
+        # デバッグ用：天気データの詳細をログ出力
+        logger.info(f"🌦️ 天気データ詳細:")
+        logger.info(f"  - 天気: {weather_data.weather_description}")
+        logger.info(f"  - 気温: {weather_data.temperature}°C")
+        logger.info(f"  - 降水量: {weather_data.precipitation}mm")
+        logger.info(f"  - hourly_forecasts属性: {hasattr(weather_data, 'hourly_forecasts')}")
+        if hasattr(weather_data, 'hourly_forecasts') and weather_data.hourly_forecasts:
+            logger.info(f"  - hourly_forecasts数: {len(weather_data.hourly_forecasts)}")
+            for i, forecast in enumerate(weather_data.hourly_forecasts[:4]):  # 最初の4つだけ
+                if hasattr(forecast, 'datetime') and hasattr(forecast, 'precipitation_mm'):
+                    logger.info(f"    [{i}] {forecast.datetime}: 降水量 {forecast.precipitation_mm}mm")
+                elif hasattr(forecast, 'precipitation'):
+                    logger.info(f"    [{i}] 降水量 {forecast.precipitation}mm")
 
         # コメント選択器の初期化
         llm_manager = LLMManager(provider=llm_provider)


### PR DESCRIPTION
- LLMプロンプトに雨天時専用の指示を追加
- 降水量>0mmの場合、雨関連表現を含むコメントを優先選択
- 候補準備時に雨関連コメントを最優先カテゴリとして分類
- 雨天時は候補リストの50%以上を雨関連コメントで構成

🤖 Generated with [Claude Code](https://claude.ai/code)