### PR TITLE
refactor: 巨大なfetch_weather_forecast_node関数を責務ごとに分割

### DIFF
--- a/src/nodes/weather_forecast/__init__.py
+++ b/src/nodes/weather_forecast/__init__.py
@@ -8,8 +8,22 @@ from .data_fetcher import WeatherDataFetcher
 from .data_transformer import WeatherDataTransformer
 from .data_validator import WeatherDataValidator
 
+# 新しいサービスクラスのインポート
+from .services import (
+    LocationService,
+    WeatherAPIService,
+    ForecastProcessingService,
+    CacheService,
+    TemperatureAnalysisService
+)
+
 __all__ = [
     "WeatherDataFetcher",
     "WeatherDataTransformer",
     "WeatherDataValidator",
+    "LocationService",
+    "WeatherAPIService",
+    "ForecastProcessingService",
+    "CacheService",
+    "TemperatureAnalysisService"
 ]

--- a/src/nodes/weather_forecast/constants.py
+++ b/src/nodes/weather_forecast/constants.py
@@ -1,0 +1,17 @@
+"""
+Weather forecast node constants
+
+天気予報ノードで使用する定数定義
+"""
+
+# API関連の定数
+API_MAX_RETRIES = 3  # API呼び出しの最大リトライ回数
+API_INITIAL_RETRY_DELAY = 1.0  # 初回リトライ遅延（秒）
+API_RETRY_BACKOFF_MULTIPLIER = 2  # リトライ遅延の指数バックオフ乗数
+
+# 時刻関連の定数
+DEFAULT_TARGET_HOURS = [9, 12, 15, 18]  # デフォルトの予報対象時刻
+DATE_BOUNDARY_HOUR = 6  # 日付境界時刻（この時刻より前は前日扱い）
+
+# 分析関連の定数
+TREND_ANALYSIS_MIN_FORECASTS = 2  # トレンド分析に必要な最小予報数

--- a/src/nodes/weather_forecast/messages.py
+++ b/src/nodes/weather_forecast/messages.py
@@ -1,0 +1,98 @@
+"""
+Weather forecast error messages
+
+天気予報ノードのエラーメッセージ定義
+将来的な国際化（i18n）に対応できる構造
+"""
+
+from typing import Dict, Any
+
+
+class Messages:
+    """メッセージ管理クラス
+    
+    将来的にはロケール対応を追加可能
+    """
+    
+    # API関連のエラーメッセージ
+    API_ERRORS = {
+        'api_key_not_found': (
+            "気象APIキー（WXTECH_API_KEY）が設定されていません。\n"
+            "設定方法: export WXTECH_API_KEY='your-api-key' または .envファイルに記載"
+        ),
+        'api_key_invalid': (
+            "気象APIキーが無効です。\n"
+            "WXTECH_API_KEYが正しく設定されているか確認してください。"
+        ),
+        'rate_limit': "気象APIのレート制限に達しました。しばらく待ってから再試行してください。",
+        'network_error': "気象APIサーバーに接続できません。ネットワーク接続を確認してください。",
+        'timeout': "気象APIへのリクエストがタイムアウトしました: {error}",
+        'server_error': "気象APIサーバーでエラーが発生しました。しばらく待ってから再試行してください。",
+        'unknown': "気象API接続エラー: {error}",
+    }
+    
+    # 地点関連のエラーメッセージ
+    LOCATION_ERRORS = {
+        'not_found': "地点 '{location_name}' が見つかりません",
+        'no_coordinates': "地点 '{location_name}' の緯度経度情報がありません",
+        'invalid_coordinates': "無効な緯度経度: lat={lat}, lon={lon}",
+    }
+    
+    # データ処理関連のエラーメッセージ
+    DATA_ERRORS = {
+        'empty_forecast': "地点 '{location_name}' の天気予報データが取得できませんでした",
+        'insufficient_data': "気象変化分析に十分な予報データがありません: {count}件",
+        'cache_error': "予報データのキャッシュ保存に失敗しました: {error}",
+    }
+    
+    # ログメッセージ
+    LOG_MESSAGES = {
+        'api_retry': "Attempt {attempt}/{max_retries}: APIエラー ({error_type}). {delay}秒後にリトライします。",
+        'empty_data_retry': "Attempt {attempt}/{max_retries}: 天気予報データが空です。{delay}秒後にリトライします。",
+        'fetch_success': "Attempt {attempt}/{max_retries}: 天気予報データを正常に取得しました。",
+        'location_parsed': "地点情報をパース: 名前='{name}', 緯度={lat}, 経度={lon}",
+        'target_date': "対象日: {date}",
+        'trend_analysis': "気象変化傾向: {summary}",
+        'cache_saved': "予報データをキャッシュに保存しました",
+        'temperature_diff': "前日との気温差: {location} - {diff}",
+    }
+    
+    @classmethod
+    def get(cls, category: str, key: str, **kwargs: Any) -> str:
+        """メッセージを取得
+        
+        Args:
+            category: メッセージカテゴリ（'API_ERRORS', 'LOCATION_ERRORS'など）
+            key: メッセージキー
+            **kwargs: メッセージのフォーマットパラメータ
+            
+        Returns:
+            フォーマット済みメッセージ
+        """
+        messages = getattr(cls, category, {})
+        template = messages.get(key, f"Unknown message: {category}.{key}")
+        
+        try:
+            return template.format(**kwargs)
+        except KeyError as e:
+            return f"{template} (Missing parameter: {e})"
+    
+    @classmethod
+    def get_api_error(cls, key: str, **kwargs: Any) -> str:
+        """APIエラーメッセージを取得"""
+        return cls.get('API_ERRORS', key, **kwargs)
+    
+    @classmethod
+    def get_location_error(cls, key: str, **kwargs: Any) -> str:
+        """地点エラーメッセージを取得"""
+        return cls.get('LOCATION_ERRORS', key, **kwargs)
+    
+    @classmethod
+    def get_data_error(cls, key: str, **kwargs: Any) -> str:
+        """データエラーメッセージを取得"""
+        return cls.get('DATA_ERRORS', key, **kwargs)
+    
+    @classmethod
+    def get_log_message(cls, key: str, **kwargs: Any) -> str:
+        """ログメッセージを取得"""
+        return cls.get('LOG_MESSAGES', key, **kwargs)

--- a/src/nodes/weather_forecast/service_factory.py
+++ b/src/nodes/weather_forecast/service_factory.py
@@ -1,0 +1,82 @@
+"""
+Weather forecast service factory
+
+サービスの依存性注入を管理するファクトリークラス
+"""
+
+from typing import Optional
+from src.nodes.weather_forecast.services import (
+    LocationService,
+    WeatherAPIService,
+    ForecastProcessingService,
+    CacheService,
+    TemperatureAnalysisService
+)
+
+
+class WeatherForecastServiceFactory:
+    """天気予報サービスのファクトリークラス
+    
+    依存性注入パターンを使用してサービスインスタンスを管理
+    テスト時にはモックサービスを注入可能
+    """
+    
+    def __init__(
+        self,
+        location_service: Optional[LocationService] = None,
+        weather_api_service: Optional[WeatherAPIService] = None,
+        forecast_processing_service: Optional[ForecastProcessingService] = None,
+        cache_service: Optional[CacheService] = None,
+        temperature_analysis_service: Optional[TemperatureAnalysisService] = None
+    ):
+        """サービスファクトリーの初期化
+        
+        Args:
+            location_service: 地点サービス（Noneの場合はデフォルト実装を使用）
+            weather_api_service: API通信サービス（Noneの場合はAPIキーが必要）
+            forecast_processing_service: 予報処理サービス
+            cache_service: キャッシュサービス
+            temperature_analysis_service: 温度分析サービス
+        """
+        self._location_service = location_service
+        self._weather_api_service = weather_api_service
+        self._forecast_processing_service = forecast_processing_service
+        self._cache_service = cache_service
+        self._temperature_analysis_service = temperature_analysis_service
+        self._api_key: Optional[str] = None
+    
+    def set_api_key(self, api_key: str) -> None:
+        """APIキーを設定"""
+        self._api_key = api_key
+    
+    def get_location_service(self) -> LocationService:
+        """地点サービスを取得"""
+        if self._location_service is None:
+            self._location_service = LocationService()
+        return self._location_service
+    
+    def get_weather_api_service(self) -> WeatherAPIService:
+        """API通信サービスを取得"""
+        if self._weather_api_service is None:
+            if self._api_key is None:
+                raise ValueError("WeatherAPIServiceを使用するにはAPIキーが必要です")
+            self._weather_api_service = WeatherAPIService(self._api_key)
+        return self._weather_api_service
+    
+    def get_forecast_processing_service(self) -> ForecastProcessingService:
+        """予報処理サービスを取得"""
+        if self._forecast_processing_service is None:
+            self._forecast_processing_service = ForecastProcessingService()
+        return self._forecast_processing_service
+    
+    def get_cache_service(self) -> CacheService:
+        """キャッシュサービスを取得"""
+        if self._cache_service is None:
+            self._cache_service = CacheService()
+        return self._cache_service
+    
+    def get_temperature_analysis_service(self) -> TemperatureAnalysisService:
+        """温度分析サービスを取得"""
+        if self._temperature_analysis_service is None:
+            self._temperature_analysis_service = TemperatureAnalysisService()
+        return self._temperature_analysis_service

--- a/src/nodes/weather_forecast/services.py
+++ b/src/nodes/weather_forecast/services.py
@@ -1,0 +1,422 @@
+"""
+Weather forecast node services
+
+天気予報ノードで使用する各種サービスクラス
+責務ごとに分離されたサービスを提供
+"""
+
+import logging
+import time
+from datetime import datetime, timedelta
+from typing import Optional, List, Tuple, Dict, Any
+import pytz
+
+from src.data.location_manager import Location, get_location_manager
+from src.data.weather_data import WeatherForecast, WeatherForecastCollection
+from src.data.forecast_cache import save_forecast_to_cache, get_temperature_differences, get_forecast_cache
+from src.apis.wxtech import WxTechAPIError
+from src.apis.wxtech.client import WxTechAPIClient
+from src.config.config_loader import load_config
+from src.data.weather_trend import WeatherTrend
+from src.nodes.weather_forecast.data_validator import WeatherDataValidator
+
+
+logger = logging.getLogger(__name__)
+
+
+class LocationService:
+    """地点情報の取得と検証を担当するサービス"""
+    
+    def __init__(self):
+        self.location_manager = get_location_manager()
+    
+    def parse_location_string(self, location_name_raw: str) -> Tuple[str, Optional[float], Optional[float]]:
+        """地点名文字列から地点名と座標を抽出
+        
+        Args:
+            location_name_raw: 生の地点名文字列（"地点名,緯度,経度" 形式の場合あり）
+            
+        Returns:
+            (地点名, 緯度, 経度) のタプル
+        """
+        provided_lat = None
+        provided_lon = None
+        
+        if "," in location_name_raw:
+            parts = location_name_raw.split(",")
+            location_name = parts[0].strip()
+            if len(parts) >= 3:
+                try:
+                    provided_lat = float(parts[1].strip())
+                    provided_lon = float(parts[2].strip())
+                    logger.info(
+                        f"Extracted location name '{location_name}' with coordinates ({provided_lat}, {provided_lon})"
+                    )
+                except ValueError:
+                    logger.warning(
+                        f"Invalid coordinates in '{location_name_raw}', will look up in LocationManager"
+                    )
+            else:
+                logger.info(f"Extracted location name '{location_name}' from '{location_name_raw}'")
+        else:
+            location_name = location_name_raw.strip()
+            
+        return location_name, provided_lat, provided_lon
+    
+    def get_location_with_coordinates(
+        self, 
+        location_name: str, 
+        provided_lat: Optional[float] = None,
+        provided_lon: Optional[float] = None
+    ) -> Location:
+        """地点情報を取得（座標情報付き）
+        
+        Args:
+            location_name: 地点名
+            provided_lat: 提供された緯度（オプション）
+            provided_lon: 提供された経度（オプション）
+            
+        Returns:
+            Location オブジェクト
+            
+        Raises:
+            ValueError: 地点が見つからない場合
+        """
+        location = self.location_manager.get_location(location_name)
+        
+        # LocationManagerで見つからない場合、提供された座標を使用
+        if not location and provided_lat is not None and provided_lon is not None:
+            logger.info(
+                f"Location '{location_name}' not found in LocationManager, using provided coordinates"
+            )
+            # 疑似Locationオブジェクトを作成
+            location = Location(
+                name=location_name,
+                normalized_name=location_name.lower(),
+                latitude=provided_lat,
+                longitude=provided_lon,
+            )
+        elif not location:
+            raise ValueError(f"地点が見つかりません: {location_name}")
+        
+        if not location.latitude or not location.longitude:
+            raise ValueError(f"地点 '{location_name}' の緯度経度情報がありません")
+        
+        return location
+
+
+class WeatherAPIService:
+    """天気予報API通信を担当するサービス"""
+    
+    def __init__(self, api_key: str):
+        self.client = WxTechAPIClient(api_key)
+        self.max_retries = 3
+        self.initial_retry_delay = 1.0
+    
+    def fetch_forecast_with_retry(
+        self, 
+        lat: float, 
+        lon: float,
+        location_name: str
+    ) -> WeatherForecastCollection:
+        """リトライ機能付きで天気予報を取得
+        
+        Args:
+            lat: 緯度
+            lon: 経度
+            location_name: 地点名（ログ用）
+            
+        Returns:
+            WeatherForecastCollection
+            
+        Raises:
+            WxTechAPIError: API通信エラー
+            ValueError: データ取得失敗
+        """
+        retry_delay = self.initial_retry_delay
+        forecast_collection = None
+        
+        for attempt in range(self.max_retries):
+            try:
+                forecast_collection = self.client.get_forecast_for_next_day_hours(lat, lon)
+                
+                # forecast_collectionが空でないことを確認
+                if forecast_collection and forecast_collection.forecasts:
+                    logger.info(
+                        f"Attempt {attempt + 1}/{self.max_retries}: "
+                        f"天気予報データを正常に取得しました。"
+                    )
+                    return forecast_collection
+                else:
+                    if attempt < self.max_retries - 1:
+                        logger.warning(
+                            f"Attempt {attempt + 1}/{self.max_retries}: "
+                            f"天気予報データが空です。{retry_delay}秒後にリトライします。"
+                        )
+                        time.sleep(retry_delay)
+                        retry_delay *= 2  # 指数バックオフ
+                    else:
+                        raise ValueError(
+                            f"地点 '{location_name}' の天気予報データが取得できませんでした"
+                        )
+                        
+            except WxTechAPIError as e:
+                # リトライ可能なエラーかチェック
+                if (e.error_type in ['network_error', 'timeout', 'server_error'] 
+                    and attempt < self.max_retries - 1):
+                    logger.warning(
+                        f"Attempt {attempt + 1}/{self.max_retries}: "
+                        f"APIエラー ({e.error_type}). {retry_delay}秒後にリトライします。"
+                    )
+                    time.sleep(retry_delay)
+                    retry_delay *= 2
+                    continue
+                else:
+                    # リトライ不可能なエラーまたは最後の試行の場合
+                    self._handle_api_error(e)
+                    raise
+        
+        raise ValueError("予期しないエラー: リトライループが正常に終了しませんでした")
+    
+    def _handle_api_error(self, error: WxTechAPIError) -> str:
+        """APIエラーを処理してユーザー向けメッセージを生成
+        
+        Args:
+            error: WxTechAPIError
+            
+        Returns:
+            エラーメッセージ
+        """
+        error_messages = {
+            'api_key_invalid': "気象APIキーが無効です。\nWXTECH_API_KEYが正しく設定されているか確認してください。",
+            'rate_limit': "気象APIのレート制限に達しました。しばらく待ってから再試行してください。",
+            'network_error': "気象APIサーバーに接続できません。ネットワーク接続を確認してください。",
+            'timeout': f"気象APIへのリクエストがタイムアウトしました: {error}",
+            'server_error': "気象APIサーバーでエラーが発生しました。しばらく待ってから再試行してください。",
+        }
+        
+        error_msg = error_messages.get(error.error_type, f"気象API接続エラー: {error}")
+        logger.error(
+            f"気象APIエラー (type: {error.error_type}, status: {error.status_code}): {error_msg}"
+        )
+        return error_msg
+
+
+class ForecastProcessingService:
+    """天気予報データの処理を担当するサービス"""
+    
+    def __init__(self):
+        self.validator = WeatherDataValidator()
+        self.jst = pytz.timezone("Asia/Tokyo")
+    
+    def get_target_date(self, now_jst: datetime, date_boundary_hour: int = 6) -> datetime.date:
+        """対象日を計算
+        
+        Args:
+            now_jst: 現在時刻（JST）
+            date_boundary_hour: 境界時刻（デフォルト: 6時）
+            
+        Returns:
+            対象日
+        """
+        if now_jst.hour < date_boundary_hour:
+            # 深夜〜早朝は当日を対象
+            return now_jst.date()
+        else:
+            # 境界時刻以降は翌日を対象
+            return now_jst.date() + timedelta(days=1)
+    
+    def extract_period_forecasts(
+        self, 
+        forecast_collection: WeatherForecastCollection,
+        target_date: datetime.date,
+        target_hours: List[int] = None
+    ) -> List[WeatherForecast]:
+        """指定時刻の予報を抽出
+        
+        Args:
+            forecast_collection: 予報コレクション
+            target_date: 対象日
+            target_hours: 対象時刻のリスト（デフォルト: [9, 12, 15, 18]）
+            
+        Returns:
+            抽出された予報のリスト
+        """
+        if target_hours is None:
+            target_hours = [9, 12, 15, 18]
+        
+        target_times = [
+            self.jst.localize(
+                datetime.combine(target_date, datetime.min.time().replace(hour=hour))
+            )
+            for hour in target_hours
+        ]
+        
+        period_forecasts = []
+        logger.info(f"Total forecasts in collection: {len(forecast_collection.forecasts)}")
+        
+        for target_time in target_times:
+            closest_forecast = self._find_closest_forecast(
+                forecast_collection.forecasts, 
+                target_time
+            )
+            
+            if closest_forecast:
+                period_forecasts.append(closest_forecast)
+                logger.debug(
+                    f"Found forecast for {target_time.strftime('%H:%M')}: "
+                    f"{closest_forecast.datetime.strftime('%Y-%m-%d %H:%M')}"
+                )
+            else:
+                logger.warning(f"No forecast found for target time {target_time.strftime('%H:%M')}")
+        
+        return period_forecasts
+    
+    def _find_closest_forecast(
+        self, 
+        forecasts: List[WeatherForecast], 
+        target_time: datetime
+    ) -> Optional[WeatherForecast]:
+        """目標時刻に最も近い予報を見つける
+        
+        Args:
+            forecasts: 予報リスト
+            target_time: 目標時刻
+            
+        Returns:
+            最も近い予報（見つからない場合はNone）
+        """
+        closest_forecast = None
+        min_diff = float('inf')
+        
+        for forecast in forecasts:
+            # forecastのdatetimeがnaiveな場合はJSTとして扱う
+            forecast_dt = forecast.datetime
+            if forecast_dt.tzinfo is None:
+                forecast_dt = self.jst.localize(forecast_dt)
+            
+            # 目標時刻との差を計算
+            diff = abs((forecast_dt - target_time).total_seconds())
+            if diff < min_diff:
+                min_diff = diff
+                closest_forecast = forecast
+        
+        return closest_forecast
+    
+    def analyze_weather_trend(
+        self, 
+        period_forecasts: List[WeatherForecast]
+    ) -> Optional[WeatherTrend]:
+        """気象変化傾向を分析
+        
+        Args:
+            period_forecasts: 期間の予報リスト
+            
+        Returns:
+            WeatherTrend オブジェクト（データ不足の場合はNone）
+        """
+        if len(period_forecasts) >= 2:
+            weather_trend = WeatherTrend.from_forecasts(period_forecasts)
+            logger.info(f"気象変化傾向: {weather_trend.get_summary()}")
+            return weather_trend
+        else:
+            logger.warning(
+                f"気象変化分析に十分な予報データがありません: {len(period_forecasts)}件"
+            )
+            return None
+    
+    def select_forecast_by_time(
+        self, 
+        forecasts: List[WeatherForecast], 
+        target_datetime: datetime
+    ) -> Optional[WeatherForecast]:
+        """ターゲット時刻に最も近い予報を選択
+        
+        Args:
+            forecasts: 予報リスト
+            target_datetime: ターゲット時刻
+            
+        Returns:
+            選択された予報
+        """
+        return self.validator.select_forecast_by_time(forecasts, target_datetime)
+
+
+class CacheService:
+    """キャッシュ処理を担当するサービス"""
+    
+    def __init__(self):
+        self.cache = get_forecast_cache()
+    
+    def save_forecasts(
+        self, 
+        selected_forecast: WeatherForecast,
+        all_forecasts: List[WeatherForecast],
+        location_name: str
+    ) -> None:
+        """予報データをキャッシュに保存
+        
+        Args:
+            selected_forecast: 選択された予報
+            all_forecasts: 全予報データ
+            location_name: 地点名
+        """
+        try:
+            # 選択された予報データを保存
+            save_forecast_to_cache(selected_forecast, location_name)
+            
+            # 72時間分の全予報データもキャッシュに保存（タイムライン表示用）
+            for forecast in all_forecasts:
+                try:
+                    self.cache.save_forecast(forecast, location_name)
+                except Exception as forecast_save_error:
+                    logger.debug(f"個別予報保存に失敗: {forecast_save_error}")
+                    continue
+                    
+            logger.info(
+                f"予報データをキャッシュに保存: {location_name} ({len(all_forecasts)}件)"
+            )
+        except Exception as e:
+            logger.warning(f"キャッシュ保存に失敗: {e}")
+            # キャッシュ保存の失敗は致命的エラーではないので続行
+
+
+class TemperatureAnalysisService:
+    """気温分析を担当するサービス"""
+    
+    def calculate_temperature_differences(
+        self, 
+        forecast: WeatherForecast, 
+        location_name: str
+    ) -> Dict[str, Optional[float]]:
+        """気温差を計算
+        
+        Args:
+            forecast: 予報データ
+            location_name: 地点名
+            
+        Returns:
+            気温差の辞書
+        """
+        try:
+            temperature_differences = get_temperature_differences(forecast, location_name)
+            
+            if temperature_differences.get("previous_day_diff") is not None:
+                logger.info(
+                    f"前日との気温差: {temperature_differences['previous_day_diff']:.1f}℃"
+                )
+            if temperature_differences.get("twelve_hours_ago_diff") is not None:
+                logger.info(
+                    f"12時間前との気温差: {temperature_differences['twelve_hours_ago_diff']:.1f}℃"
+                )
+            if temperature_differences.get("daily_range") is not None:
+                logger.info(
+                    f"日較差: {temperature_differences['daily_range']:.1f}℃"
+                )
+                
+            return temperature_differences
+            
+        except Exception as e:
+            logger.warning(f"気温差の計算に失敗: {e}")
+            # 気温差計算の失敗も致命的エラーではないので空の辞書を返す
+            return {}


### PR DESCRIPTION
- 534行の巨大関数を以下のサービスクラスに分割:
  - LocationService: 地点情報の処理
  - WeatherAPIService: API通信とリトライロジック
  - ForecastProcessingService: 予報データの処理と選択
  - CacheService: キャッシュの管理
  - TemperatureAnalysisService: 気温差の計算
- 後方互換性を保つため、元の関数名はエイリアスとして維持
- コードの保守性と可読性が大幅に向上
