### PR TITLE
refactor: 古い型ヒント構文をPython 3.9+の新しい構文に変換

### DIFF
--- a/scripts/add_future_annotations.py
+++ b/scripts/add_future_annotations.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+__future__ import annotationsを追加するスクリプト
+
+Python 3.10+では、from __future__ import annotationsを使用することで、
+型ヒントの評価を遅延させ、より簡潔な記法が可能になります。
+"""
+
+import re
+from pathlib import Path
+
+
+def add_future_annotations(file_path: Path) -> bool:
+    """単一ファイルに__future__ annotationsを追加"""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    # すでに存在する場合はスキップ
+    if 'from __future__ import annotations' in content:
+        return False
+    
+    # ファイルの先頭を解析
+    lines = content.split('\n')
+    
+    # シバン、エンコーディング、docstringを見つける
+    insert_index = 0
+    in_docstring = False
+    docstring_delimiter = None
+    
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        
+        # シバンまたはエンコーディング宣言
+        if i == 0 and (stripped.startswith('#!') or stripped.startswith('# -*- coding')):
+            insert_index = i + 1
+            continue
+        
+        # docstringの開始/終了を検出
+        if not in_docstring and (stripped.startswith('"""') or stripped.startswith("'''")):
+            in_docstring = True
+            docstring_delimiter = '"""' if stripped.startswith('"""') else "'''"
+            if stripped.count(docstring_delimiter) >= 2:  # 単一行のdocstring
+                in_docstring = False
+                insert_index = i + 1
+            continue
+        
+        if in_docstring and docstring_delimiter in stripped:
+            in_docstring = False
+            insert_index = i + 1
+            continue
+        
+        # 最初のimport文またはコード行を見つけたら、その前に挿入
+        if not in_docstring and stripped and not stripped.startswith('#'):
+            insert_index = i
+            break
+    
+    # __future__ importを追加
+    future_import = "from __future__ import annotations\n"
+    
+    # 適切な位置に挿入
+    if insert_index > 0 and lines[insert_index - 1].strip():
+        # 前の行が空でない場合は空行を追加
+        future_import = "\n" + future_import
+    
+    if insert_index < len(lines) and lines[insert_index].strip():
+        # 次の行が空でない場合は空行を追加
+        future_import = future_import + "\n"
+    
+    lines.insert(insert_index, future_import.rstrip())
+    
+    # ファイルを更新
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
+    
+    return True
+
+
+def main():
+    """メイン処理"""
+    print("__future__ import annotationsを追加します...")
+    
+    # 対象ディレクトリ
+    src_dir = Path(__file__).parent.parent / "src"
+    
+    total_files = 0
+    updated_files = 0
+    
+    if src_dir.exists():
+        for py_file in src_dir.rglob("*.py"):
+            # __pycache__を除外
+            if "__pycache__" in str(py_file):
+                continue
+            
+            # __init__.pyは除外（短いファイルが多いため）
+            if py_file.name == "__init__.py":
+                continue
+            
+            total_files += 1
+            if add_future_annotations(py_file):
+                print(f"✓ {py_file.relative_to(src_dir.parent)}")
+                updated_files += 1
+    
+    print(f"\n完了: {updated_files}/{total_files} ファイルを更新しました")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/modernize_callable.py
+++ b/scripts/modernize_callable.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+CallableをPython 3.9+推奨のcollections.abc.Callableに変換するスクリプト
+"""
+
+import re
+from pathlib import Path
+from collections.abc import Callable as AbcCallable
+
+def modernize_callable_imports(file_path: Path) -> int:
+    """単一ファイルのCallableインポートを更新"""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    original_content = content
+    changes = 0
+    
+    # typing.Callableのインポートパターンを見つける
+    patterns = [
+        # from typing import Callable
+        (r'from typing import (.*?)Callable(.*?)(?=\n|$)', 
+         lambda m: process_typing_import(m.group(0), m.group(1), m.group(2))),
+        # from typing import ..., Callable, ...
+        (r'from typing import ([^;\n]*)', 
+         lambda m: process_full_typing_import(m.group(0))),
+    ]
+    
+    for pattern, processor in patterns:
+        content = re.sub(pattern, processor, content)
+    
+    # collections.abc.Callableのインポートを追加（必要な場合）
+    if 'Callable' in content and 'from collections.abc import' not in content:
+        # typingインポートの後に追加
+        typing_import = re.search(r'from typing import[^\n]+\n', content)
+        if typing_import:
+            insert_pos = typing_import.end()
+            content = content[:insert_pos] + 'from collections.abc import Callable\n' + content[insert_pos:]
+            changes += 1
+    
+    if content != original_content:
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+        changes += 1
+    
+    return changes
+
+
+def process_typing_import(full_match: str, before: str, after: str) -> str:
+    """typing importからCallableを除去"""
+    # 前後の要素を取得
+    before_items = [item.strip() for item in before.split(',') if item.strip()]
+    after_items = [item.strip() for item in after.split(',') if item.strip() and item.strip() != '']
+    
+    all_items = before_items + after_items
+    
+    if not all_items:
+        # Callableのみの場合、行を削除
+        return ''
+    else:
+        # 他の要素がある場合
+        return f"from typing import {', '.join(all_items)}"
+
+
+def process_full_typing_import(full_match: str) -> str:
+    """完全なtypingインポート文を処理"""
+    if 'Callable' not in full_match:
+        return full_match
+    
+    # インポートされている要素を抽出
+    match = re.search(r'from typing import (.+)', full_match)
+    if not match:
+        return full_match
+    
+    imports = match.group(1)
+    items = [item.strip() for item in imports.split(',')]
+    
+    # Callableを除去
+    items = [item for item in items if 'Callable' not in item]
+    
+    if not items:
+        return ''
+    
+    return f"from typing import {', '.join(items)}"
+
+
+def main():
+    """メイン処理"""
+    print("Callableの型ヒントをcollections.abc.Callableに更新します...")
+    
+    # 対象ディレクトリ
+    src_dir = Path(__file__).parent.parent / "src"
+    tests_dir = Path(__file__).parent.parent / "tests"
+    
+    total_files = 0
+    total_changes = 0
+    
+    for directory in [src_dir, tests_dir]:
+        if not directory.exists():
+            continue
+            
+        for py_file in directory.rglob("*.py"):
+            # __pycache__を除外
+            if "__pycache__" in str(py_file):
+                continue
+            
+            changes = modernize_callable_imports(py_file)
+            if changes > 0:
+                print(f"✓ {py_file}: 更新しました")
+                total_files += 1
+                total_changes += changes
+    
+    print(f"\n完了: {total_files} ファイルを更新しました")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/modernize_type_hints.py
+++ b/scripts/modernize_type_hints.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 # 変換マッピング
 TYPE_MAPPINGS = {
-    r'\bDict\[([^]]+)\]': r'dict[\1]',
+    # TypedDictを含まないようにDict前に負の先読みアサーションを追加
+    r'\b(?<!Type)Dict\[([^]]+)\]': r'dict[\1]',
     r'\bList\[([^]]+)\]': r'list[\1]',
     r'\bTuple\[([^]]+)\]': r'tuple[\1]',
     r'\bSet\[([^]]+)\]': r'set[\1]',

--- a/src/algorithms/comment_evaluator.py
+++ b/src/algorithms/comment_evaluator.py
@@ -4,6 +4,7 @@
 コメントの品質を多角的に評価する機能
 """
 
+from __future__ import annotations
 from typing import Any
 import re
 import logging

--- a/src/algorithms/evaluators/appropriateness_evaluator.py
+++ b/src/algorithms/evaluators/appropriateness_evaluator.py
@@ -4,6 +4,7 @@
 コメントの社会的・倫理的な適切性を評価する
 """
 
+from __future__ import annotations
 import re
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext

--- a/src/algorithms/evaluators/base_evaluator.py
+++ b/src/algorithms/evaluators/base_evaluator.py
@@ -4,6 +4,7 @@
 すべての評価基準の共通インターフェースを定義
 """
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 import re

--- a/src/algorithms/evaluators/clarity_evaluator.py
+++ b/src/algorithms/evaluators/clarity_evaluator.py
@@ -4,6 +4,7 @@
 コメントの明確性と具体性を評価する
 """
 
+from __future__ import annotations
 import re
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext

--- a/src/algorithms/evaluators/consistency_evaluator.py
+++ b/src/algorithms/evaluators/consistency_evaluator.py
@@ -4,6 +4,7 @@
 コメント間の一貫性と整合性を評価する
 """
 
+from __future__ import annotations
 from typing import Any
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext

--- a/src/algorithms/evaluators/creativity_evaluator.py
+++ b/src/algorithms/evaluators/creativity_evaluator.py
@@ -4,6 +4,7 @@
 コメントの創造性と独創性を評価する
 """
 
+from __future__ import annotations
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext
 from src.data.comment_pair import CommentPair

--- a/src/algorithms/evaluators/engagement_evaluator.py
+++ b/src/algorithms/evaluators/engagement_evaluator.py
@@ -4,6 +4,7 @@
 ユーザーとのエンゲージメントを促進する要素を評価する
 """
 
+from __future__ import annotations
 import re
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext

--- a/src/algorithms/evaluators/evaluator_config.py
+++ b/src/algorithms/evaluators/evaluator_config.py
@@ -4,6 +4,7 @@
 各評価器で使用する設定を一元管理
 """
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/src/algorithms/evaluators/naturalness_evaluator.py
+++ b/src/algorithms/evaluators/naturalness_evaluator.py
@@ -4,6 +4,7 @@
 コメントの文法的・言語的な自然さを評価する
 """
 
+from __future__ import annotations
 import re
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext

--- a/src/algorithms/evaluators/originality_evaluator.py
+++ b/src/algorithms/evaluators/originality_evaluator.py
@@ -4,6 +4,7 @@
 コメントの独自性と新規性を評価する
 """
 
+from __future__ import annotations
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext
 from src.data.comment_pair import CommentPair

--- a/src/algorithms/evaluators/relevance_evaluator.py
+++ b/src/algorithms/evaluators/relevance_evaluator.py
@@ -4,6 +4,7 @@
 天気条件との関連性を評価する
 """
 
+from __future__ import annotations
 from typing import Any
 from src.algorithms.evaluators.base_evaluator import BaseEvaluator
 from src.data.evaluation_criteria import EvaluationCriteria, CriterionScore, EvaluationContext

--- a/src/algorithms/similarity_calculator.py
+++ b/src/algorithms/similarity_calculator.py
@@ -4,6 +4,7 @@
 天気条件やセマンティック類似度を計算する機能
 """
 
+from __future__ import annotations
 import math
 from typing import Any
 from datetime import datetime

--- a/src/apis/wxtech/api.py
+++ b/src/apis/wxtech/api.py
@@ -4,6 +4,7 @@ WxTech API リクエスト処理
 低レベルのHTTPリクエスト処理とレート制限を管理
 """
 
+from __future__ import annotations
 from typing import Any
 import requests
 import json

--- a/src/apis/wxtech/async_client.py
+++ b/src/apis/wxtech/async_client.py
@@ -4,6 +4,7 @@
 aiohttpを使用した真の非同期実装
 """
 
+from __future__ import annotations
 import asyncio
 import logging
 import os

--- a/src/apis/wxtech/cached_client.py
+++ b/src/apis/wxtech/cached_client.py
@@ -4,6 +4,7 @@
 キャッシュ機能を持つWxTech APIクライアントの実装
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 import os

--- a/src/apis/wxtech/client.py
+++ b/src/apis/wxtech/client.py
@@ -4,6 +4,7 @@ WxTech API クライアント
 高レベルのAPI操作インターフェースを提供
 """
 
+from __future__ import annotations
 from typing import Any
 import asyncio
 from concurrent.futures import ThreadPoolExecutor

--- a/src/apis/wxtech/errors.py
+++ b/src/apis/wxtech/errors.py
@@ -6,6 +6,7 @@ WxTech API で発生するエラーの定義と処理を管理
 
 
 
+from __future__ import annotations
 class WxTechAPIError(Exception):
     """WxTech API エラー
     

--- a/src/apis/wxtech/mappings.py
+++ b/src/apis/wxtech/mappings.py
@@ -4,6 +4,7 @@ WxTech API 天気コードマッピング
 天気コードと風向きの変換定義を管理
 """
 
+from __future__ import annotations
 from src.data.weather_data import WeatherCondition, WindDirection
 
 

--- a/src/apis/wxtech/parser.py
+++ b/src/apis/wxtech/parser.py
@@ -4,6 +4,7 @@ WxTech API データパーサー
 APIレスポンスをドメインモデルに変換する処理を管理
 """
 
+from __future__ import annotations
 from typing import Any
 import warnings
 from datetime import datetime

--- a/src/apis/wxtech_client.py
+++ b/src/apis/wxtech_client.py
@@ -5,6 +5,7 @@ WxTech API クライアント(後方互換性のためのラッパー)
 新しいコードでは src.apis.wxtech モジュールを直接インポートしてください。
 """
 
+from __future__ import annotations
 import warnings
 
 # 後方互換性のためのインポート

--- a/src/config/__main__.py
+++ b/src/config/__main__.py
@@ -5,6 +5,7 @@
     python -m src.config
 """
 
+from __future__ import annotations
 from .validate import main
 
 if __name__ == "__main__":

--- a/src/config/app_config.py
+++ b/src/config/app_config.py
@@ -1,5 +1,6 @@
 """アプリケーション設定の統一管理（非推奨: config.pyを使用してください）"""
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/config/app_settings.py
+++ b/src/config/app_settings.py
@@ -4,6 +4,7 @@
 全体の設定を統合管理する
 """
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/config/cache_config.py
+++ b/src/config/cache_config.py
@@ -4,6 +4,7 @@
 環境変数または設定ファイルからキャッシュパラメータを読み込む
 """
 
+from __future__ import annotations
 import os
 from typing import Any
 

--- a/src/config/comment_config.py
+++ b/src/config/comment_config.py
@@ -1,5 +1,6 @@
 """コメント生成に関する設定"""
 
+from __future__ import annotations
 from dataclasses import dataclass
 
 from src.data.weather_data import WeatherCondition

--- a/src/config/compatibility.py
+++ b/src/config/compatibility.py
@@ -4,6 +4,7 @@
 既存の設定クラスから新しい統一設定への移行を支援
 """
 
+from __future__ import annotations
 import warnings
 import logging
 from typing import Any

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -4,6 +4,7 @@
 設定は論理的なグループに分割され、settings/ディレクトリ内の各モジュールで定義されています。
 """
 
+from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -1,5 +1,6 @@
 """設定ファイルの読み込みユーティリティ"""
 
+from __future__ import annotations
 import yaml
 from pathlib import Path
 from typing import Any

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -5,6 +5,8 @@
 """
 
 # 温度差閾値設定（気象学的根拠に基づく）
+
+from __future__ import annotations
 TEMP_DIFF_THRESHOLD_PREVIOUS_DAY = 5.0  # 前日比5℃: 人体が明確に体感できる温度差
 TEMP_DIFF_THRESHOLD_12HOURS = 3.0  # 12時間前比3℃: 体調管理に影響する可能性がある基準値
 DAILY_TEMP_RANGE_THRESHOLD_LARGE = 15.0  # 日較差15℃: 健康影響リスクが高まる閾値

--- a/src/config/env_schema.py
+++ b/src/config/env_schema.py
@@ -4,6 +4,7 @@
 環境変数の一覧、型、デフォルト値を管理
 """
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 from enum import Enum

--- a/src/config/evaluation_config_loader.py
+++ b/src/config/evaluation_config_loader.py
@@ -1,5 +1,6 @@
 """評価設定ローダー"""
 
+from __future__ import annotations
 import yaml
 from typing import Any
 from pathlib import Path

--- a/src/config/langgraph_settings.py
+++ b/src/config/langgraph_settings.py
@@ -4,6 +4,7 @@ LangGraph統合機能の設定管理
 LangGraph関連の設定を管理する
 """
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/config/settings/api_settings.py
+++ b/src/config/settings/api_settings.py
@@ -1,5 +1,6 @@
 """API関連の設定モジュール"""
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/config/settings/app_settings.py
+++ b/src/config/settings/app_settings.py
@@ -1,5 +1,6 @@
 """アプリケーション全体の設定モジュール"""
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/src/config/settings/comment_settings.py
+++ b/src/config/settings/comment_settings.py
@@ -1,5 +1,6 @@
 """コメント生成関連の設定モジュール"""
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/config/settings/llm_settings.py
+++ b/src/config/settings/llm_settings.py
@@ -1,5 +1,6 @@
 """LLM（大規模言語モデル）関連の設定モジュール"""
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 

--- a/src/config/settings/ui_data_settings.py
+++ b/src/config/settings/ui_data_settings.py
@@ -1,5 +1,6 @@
 """UI・データ関連の設定モジュール"""
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/src/config/settings/weather_settings.py
+++ b/src/config/settings/weather_settings.py
@@ -1,5 +1,6 @@
 """天気予報関連の設定モジュール"""
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/src/config/severe_weather_config.py
+++ b/src/config/severe_weather_config.py
@@ -1,5 +1,6 @@
 """悪天候時のコメント選択設定"""
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 from src.data.weather_data import WeatherCondition

--- a/src/config/similarity_config.py
+++ b/src/config/similarity_config.py
@@ -1,5 +1,6 @@
 """類似度計算の設定"""
 
+from __future__ import annotations
 from dataclasses import dataclass
 
 

--- a/src/config/unified_config.py
+++ b/src/config/unified_config.py
@@ -5,6 +5,7 @@
 新しいコードではsrc.config.configを使用してください。
 """
 
+from __future__ import annotations
 import warnings
 from typing import Any
 

--- a/src/config/unified_config_shim.py
+++ b/src/config/unified_config_shim.py
@@ -2,6 +2,7 @@
 unified_config.pyとの互換性のためのシムクラス
 """
 
+from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -6,6 +6,7 @@
     python -m src.config.validate
 """
 
+from __future__ import annotations
 import sys
 import json
 import logging

--- a/src/config/weather_config.py
+++ b/src/config/weather_config.py
@@ -9,6 +9,8 @@
 """
 
 # 後方互換性のために全てのクラスと関数を再エクスポート
+
+from __future__ import annotations
 from .config import get_weather_config, get_langgraph_config
 from .app_settings import (
     AppConfig,

--- a/src/config/weather_constants.py
+++ b/src/config/weather_constants.py
@@ -1,6 +1,8 @@
 """天気関連の定数定義"""
 
 # 気温閾値 (°C)
+
+from __future__ import annotations
 class TemperatureThresholds:
     """気温閾値の定数"""
     HOT_WEATHER = 30.0          # 暑い天気の閾値

--- a/src/config/weather_settings.py
+++ b/src/config/weather_settings.py
@@ -5,6 +5,7 @@
 新しいコードでは src.config.config から get_weather_config() を使用してください。
 """
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/constants/content_constants.py
+++ b/src/constants/content_constants.py
@@ -1,6 +1,8 @@
 """Content-related constants."""
 
 # Severe weather patterns
+
+from __future__ import annotations
 SEVERE_WEATHER_PATTERNS = [
     "大雨", "豪雨", "暴風", "台風", "雷", "嵐", "大雪", "吹雪"
 ]

--- a/src/constants/system_constants.py
+++ b/src/constants/system_constants.py
@@ -1,6 +1,8 @@
 """System-related constants."""
 
 # Batch processing
+
+from __future__ import annotations
 DEFAULT_BATCH_SIZE = 10
 MAX_BATCH_SIZE = 100
 

--- a/src/constants/time_constants.py
+++ b/src/constants/time_constants.py
@@ -1,6 +1,8 @@
 """Time-related constants."""
 
 # Time period boundaries (hours)
+
+from __future__ import annotations
 MORNING_START_HOUR = 5
 MORNING_END_HOUR = 10
 NOON_START_HOUR = 10

--- a/src/constants/validation_constants.py
+++ b/src/constants/validation_constants.py
@@ -1,5 +1,6 @@
 """バリデーション関連の定数"""
 
+from __future__ import annotations
 import re
 
 # 類似度の閾値

--- a/src/constants/validation_thresholds.py
+++ b/src/constants/validation_thresholds.py
@@ -1,6 +1,8 @@
 """Validation threshold constants."""
 
 # Temperature thresholds for symptom checks (Celsius)
+
+from __future__ import annotations
 HEATSTROKE_WARNING_TEMP = 35.0  # 熱中症警告温度
 COLD_PREVENTION_TEMP = 15.0     # 防寒対策推奨温度
 COMFORTABLE_HIGH_TEMP = 30.0     # 快適上限温度

--- a/src/constants/weather_constants.py
+++ b/src/constants/weather_constants.py
@@ -4,6 +4,7 @@
 関連する定数はクラスでグループ化されており、保守性と可読性を向上させています。
 """
 
+from __future__ import annotations
 from dataclasses import dataclass
 
 

--- a/src/controllers/async_batch_processor.py
+++ b/src/controllers/async_batch_processor.py
@@ -3,9 +3,11 @@
 複数地点の天気予報を並列で非同期取得する最適化版
 """
 
+from __future__ import annotations
 import asyncio
 import logging
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from datetime import datetime
 
 from src.apis.wxtech.cached_client import CachedWxTechAPIClient

--- a/src/controllers/async_batch_processor.py
+++ b/src/controllers/async_batch_processor.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Callable
 from datetime import datetime
 
 from src.apis.wxtech.cached_client import CachedWxTechAPIClient
@@ -106,7 +106,7 @@ class AsyncBatchProcessor:
         self,
         locations: list[str],
         llm_provider: str = "gemini",
-        progress_callback: callable | None = None
+        progress_callback: Callable[[int, int, str | None], None] | None = None
     ) -> BatchGenerationResult:
         """複数地点のコメントを非同期で生成
         

--- a/src/controllers/batch_processor.py
+++ b/src/controllers/batch_processor.py
@@ -1,8 +1,9 @@
 """バッチ処理モジュール"""
 
+from __future__ import annotations
 import asyncio
 import logging
-from typing import Callable
+
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.types import LocationResult, BatchGenerationResult

--- a/src/controllers/batch_processor.py
+++ b/src/controllers/batch_processor.py
@@ -38,7 +38,7 @@ class BatchProcessor:
         locations: list[str],
         llm_provider: str,
         generate_func: Callable[[str, str], LocationResult],
-        progress_callback: Callable[[int, int, str | None, None]] = None,
+        progress_callback: Callable[[int, int, str | None], None] | None = None,
         max_workers: int | None = None
     ) -> BatchGenerationResult:
         """非同期バッチ処理（asyncio版）"""
@@ -95,7 +95,7 @@ class BatchProcessor:
         llm_provider: str,
         idx: int,
         total: int,
-        progress_callback: Callable[[int, int, str | None, None]],
+        progress_callback: Callable[[int, int, str | None], None],
         semaphore: asyncio.Semaphore
     ) -> LocationResult:
         """単一地点の処理（コールバック付き）"""
@@ -114,7 +114,7 @@ class BatchProcessor:
         locations: list[str],
         llm_provider: str,
         generate_func: Callable[[str, str], LocationResult],
-        progress_callback: Callable[[int, int, str | None, None]] = None,
+        progress_callback: Callable[[int, int, str | None], None] | None = None,
         max_workers: int | None = None
     ) -> BatchGenerationResult:
         """同期バッチ処理（ThreadPoolExecutor版）- 後方互換性のため"""

--- a/src/controllers/config_manager.py
+++ b/src/controllers/config_manager.py
@@ -3,6 +3,7 @@
 CommentGenerationControllerから設定管理の責務を分離。
 """
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.config.app_config import AppConfig, get_config

--- a/src/controllers/history_manager.py
+++ b/src/controllers/history_manager.py
@@ -3,6 +3,7 @@
 CommentGenerationControllerから履歴管理の責務を分離。
 """
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.ui.streamlit_utils import load_history, save_to_history

--- a/src/controllers/history_manager.py
+++ b/src/controllers/history_manager.py
@@ -23,7 +23,7 @@ class HistoryManager:
             self._generation_history = load_history()
         return self._generation_history
     
-    def save_generation_result(self, result: Dict, location: str, llm_provider: str) -> None:
+    def save_generation_result(self, result: dict[str, Any], location: str, llm_provider: str) -> None:
         """生成結果を履歴に保存"""
         if result.get('success'):
             save_to_history(result, location, llm_provider)

--- a/src/controllers/metadata_extractor.py
+++ b/src/controllers/metadata_extractor.py
@@ -1,5 +1,6 @@
 """メタデータ抽出モジュール"""
 
+from __future__ import annotations
 import logging
 from datetime import datetime
 import pytz

--- a/src/controllers/progress_handler.py
+++ b/src/controllers/progress_handler.py
@@ -5,8 +5,10 @@
 インターフェースを定義しています。
 """
 
+from __future__ import annotations
 import asyncio
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 from concurrent.futures import Future
 
 import streamlit as st

--- a/src/controllers/refactored_comment_generation_controller.py
+++ b/src/controllers/refactored_comment_generation_controller.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import logging
-from typing import Callable
+from typing import Callable, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.types import LocationResult, BatchGenerationResult
@@ -106,7 +106,7 @@ class RefactoredCommentGenerationController(ICommentGenerationController):
         self, 
         locations: list[str], 
         llm_provider: str,
-        progress_callback: Callable[[int, int, str | None, None]] = None, 
+        progress_callback: Callable[[int, int, str | None], None] | None = None, 
         max_workers: int | None = None
     ) -> BatchGenerationResult:
         """複数地点のコメント生成（並列処理版）"""
@@ -180,7 +180,7 @@ class RefactoredCommentGenerationController(ICommentGenerationController):
     
     # === プライベートメソッド ===
     
-    def _log_weather_timeline(self, location: str, result: Dict) -> None:
+    def _log_weather_timeline(self, location: str, result: dict[str, Any]) -> None:
         """weather_timelineのデバッグログ出力"""
         generation_metadata = result.get('generation_metadata', {})
         weather_timeline = generation_metadata.get('weather_timeline', {})
@@ -192,7 +192,7 @@ class RefactoredCommentGenerationController(ICommentGenerationController):
         else:
             logger.warning(f"Controller: location={location}, weather_timelineが存在しません")
     
-    def _build_location_result(self, location: str, result: Dict) -> LocationResult:
+    def _build_location_result(self, location: str, result: dict[str, Any]) -> LocationResult:
         """LocationResult型の結果を構築"""
         location_result: LocationResult = {
             'location': location,
@@ -226,7 +226,7 @@ class RefactoredCommentGenerationController(ICommentGenerationController):
         locations: list[str],
         llm_provider: str,
         progress_callback: Callable,
-        all_results: List,
+        all_results: list[LocationResult],
         results_container,
         view
     ) -> BatchGenerationResult:

--- a/src/controllers/refactored_comment_generation_controller.py
+++ b/src/controllers/refactored_comment_generation_controller.py
@@ -3,9 +3,11 @@
 単一責任原則に従い、責務を適切に分離。
 """
 
+from __future__ import annotations
 import asyncio
 import logging
-from typing import Callable, Any
+from typing import Any
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.types import LocationResult, BatchGenerationResult

--- a/src/controllers/ui_adapters.py
+++ b/src/controllers/ui_adapters.py
@@ -1,5 +1,6 @@
 """UIフレームワークアダプター"""
 
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from src.controllers.ui_interfaces import (

--- a/src/controllers/ui_interfaces.py
+++ b/src/controllers/ui_interfaces.py
@@ -1,5 +1,6 @@
 """UIフレームワーク非依存のインターフェース定義"""
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Protocol, runtime_checkable
 

--- a/src/controllers/validators.py
+++ b/src/controllers/validators.py
@@ -1,5 +1,6 @@
 """バリデーションモジュール"""
 
+from __future__ import annotations
 from typing import Any
 from src.config.app_config import AppConfig
 

--- a/src/data/comment_generation_state.py
+++ b/src/data/comment_generation_state.py
@@ -5,6 +5,7 @@
 状態データを管理するデータクラスを定義します。
 """
 
+from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/data/comment_pair.py
+++ b/src/data/comment_pair.py
@@ -4,6 +4,7 @@
 天気コメントとアドバイスのペアを管理するデータクラス
 """
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 from datetime import datetime

--- a/src/data/evaluation_criteria.py
+++ b/src/data/evaluation_criteria.py
@@ -4,6 +4,7 @@
 コメント候補の評価に使用するデータ構造
 """
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 from datetime import datetime

--- a/src/data/forecast_cache.py
+++ b/src/data/forecast_cache.py
@@ -5,6 +5,7 @@
 前日との気温差や日較差の比較を可能にする
 """
 
+from __future__ import annotations
 import ast
 import csv
 import re

--- a/src/data/location/csv_loader.py
+++ b/src/data/location/csv_loader.py
@@ -1,5 +1,6 @@
 """地点データCSVローダー - CSVファイルから地点データを読み込む"""
 
+from __future__ import annotations
 import csv
 import logging
 from pathlib import Path

--- a/src/data/location/manager.py
+++ b/src/data/location/manager.py
@@ -1,5 +1,6 @@
 """リファクタリングされた地点データ管理システム - ファサードパターンで各コンポーネントを統合"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from pathlib import Path

--- a/src/data/location/models.py
+++ b/src/data/location/models.py
@@ -1,5 +1,6 @@
 """地点データモデル - Locationデータクラスの定義"""
 
+from __future__ import annotations
 import re
 import unicodedata
 from dataclasses import dataclass, field

--- a/src/data/location/search_engine.py
+++ b/src/data/location/search_engine.py
@@ -1,5 +1,6 @@
 """地点データ検索エンジン - 地点データの高速検索機能を提供"""
 
+from __future__ import annotations
 import logging
 from collections import defaultdict
 

--- a/src/data/location/trie.py
+++ b/src/data/location/trie.py
@@ -1,5 +1,6 @@
 """Trie（トライ木）データ構造の実装 - 効率的な前方一致検索用"""
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 
 

--- a/src/data/past_comment.py
+++ b/src/data/past_comment.py
@@ -6,6 +6,8 @@
 """
 
 # 分割されたモジュールから再エクスポート
+
+from __future__ import annotations
 from src.data.past_comment.models import PastComment, CommentType
 from src.data.past_comment.collection import PastCommentCollection
 from src.data.past_comment.similarity import matches_weather_condition, calculate_similarity_score

--- a/src/data/past_comment/collection.py
+++ b/src/data/past_comment/collection.py
@@ -1,5 +1,6 @@
 """過去コメントのコレクション管理"""
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 from collections import Counter

--- a/src/data/past_comment/models.py
+++ b/src/data/past_comment/models.py
@@ -1,5 +1,6 @@
 """過去コメントのデータモデル"""
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any

--- a/src/data/past_comment/similarity.py
+++ b/src/data/past_comment/similarity.py
@@ -1,5 +1,6 @@
 """過去コメントの類似度計算"""
 
+from __future__ import annotations
 from src.config.similarity_config import get_similarity_config
 
 

--- a/src/data/storage/base.py
+++ b/src/data/storage/base.py
@@ -4,6 +4,7 @@
 DynamoDBとローカルストレージの両方に対応できる基底クラス
 """
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 from datetime import datetime

--- a/src/data/weather_data.py
+++ b/src/data/weather_data.py
@@ -4,6 +4,7 @@
 WxTech APIからの天気予報データを標準化して扱うためのクラス群
 """
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any

--- a/src/data/weather_trend.py
+++ b/src/data/weather_trend.py
@@ -1,5 +1,6 @@
 """気象変化の傾向を表現するデータクラス"""
 
+from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any

--- a/src/exceptions/error_types.py
+++ b/src/exceptions/error_types.py
@@ -1,5 +1,6 @@
 """Standardized error types and error handling for the application"""
 
+from __future__ import annotations
 from enum import Enum
 from typing import Any
 

--- a/src/formatters/debug_info_formatter.py
+++ b/src/formatters/debug_info_formatter.py
@@ -4,6 +4,7 @@ Debug Info Formatter
 デバッグ情報を作成する
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 

--- a/src/formatters/final_comment_formatter.py
+++ b/src/formatters/final_comment_formatter.py
@@ -2,6 +2,7 @@
 最終コメントフォーマッター
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 import re

--- a/src/formatters/json_output_formatter.py
+++ b/src/formatters/json_output_formatter.py
@@ -4,6 +4,7 @@ JSON Output Formatter
 最終結果をJSON形式で整形し、クリーンアップ処理を行う
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 import json

--- a/src/formatters/metadata_formatter.py
+++ b/src/formatters/metadata_formatter.py
@@ -2,6 +2,7 @@
 メタデータフォーマッター
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 from datetime import datetime

--- a/src/formatters/weather_timeline_formatter.py
+++ b/src/formatters/weather_timeline_formatter.py
@@ -2,6 +2,7 @@
 天気タイムラインフォーマッター
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 from datetime import datetime, timedelta

--- a/src/llm/llm_manager.py
+++ b/src/llm/llm_manager.py
@@ -3,6 +3,7 @@
 複数のLLMプロバイダーを統一的に管理するマネージャークラス。
 """
 
+from __future__ import annotations
 import os
 from typing import Any
 import logging

--- a/src/llm/prompt_builder.py
+++ b/src/llm/prompt_builder.py
@@ -5,6 +5,7 @@
 効果的な天気コメント生成用プロンプトを構築します。
 """
 
+from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass

--- a/src/llm/prompt_templates.py
+++ b/src/llm/prompt_templates.py
@@ -1,6 +1,8 @@
 """プロンプトテンプレート定義"""
 
 # コメント生成用プロンプトテンプレート
+
+from __future__ import annotations
 COMMENT_GENERATION_PROMPT = """あなたは天気予報のコメント作成者です。以下の条件でコメントを生成してください。
 
 【現在の天気情報】

--- a/src/llm/providers/anthropic_provider.py
+++ b/src/llm/providers/anthropic_provider.py
@@ -1,5 +1,6 @@
 """Anthropic Claude APIプロバイダー"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 

--- a/src/llm/providers/base_provider.py
+++ b/src/llm/providers/base_provider.py
@@ -1,5 +1,6 @@
 """LLMプロバイダーの基底クラス"""
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/src/llm/providers/gemini_provider.py
+++ b/src/llm/providers/gemini_provider.py
@@ -1,5 +1,6 @@
 """Google Gemini APIプロバイダー"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 

--- a/src/llm/providers/openai_provider.py
+++ b/src/llm/providers/openai_provider.py
@@ -1,5 +1,6 @@
 """OpenAI APIプロバイダー"""
 
+from __future__ import annotations
 import logging
 import time
 from typing import Any

--- a/src/nodes/comment_selector.py
+++ b/src/nodes/comment_selector.py
@@ -1,6 +1,8 @@
 """コメント選択ロジックを分離したクラス - 後方互換性のためのラッパー"""
 
 # 後方互換性のため、新しいモジュール構造から再エクスポート
+
+from __future__ import annotations
 from src.nodes.comment_selector.base_selector import CommentSelector
 
 __all__ = ['CommentSelector']

--- a/src/nodes/comment_selector/base_selector.py
+++ b/src/nodes/comment_selector/base_selector.py
@@ -1,5 +1,6 @@
 """コメント選択の基本クラス"""
 
+from __future__ import annotations
 import logging
 from datetime import datetime
 from typing import Any

--- a/src/nodes/comment_selector/llm_selector.py
+++ b/src/nodes/comment_selector/llm_selector.py
@@ -1,5 +1,6 @@
 """LLMを使用したコメント選択ロジック"""
 
+from __future__ import annotations
 import logging
 import re
 from datetime import datetime

--- a/src/nodes/comment_selector/utils.py
+++ b/src/nodes/comment_selector/utils.py
@@ -1,5 +1,6 @@
 """コメント選択のユーティリティ関数"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from functools import lru_cache

--- a/src/nodes/comment_selector/validation.py
+++ b/src/nodes/comment_selector/validation.py
@@ -1,5 +1,6 @@
 """コメントバリデーションロジック（リファクタリング版）"""
 
+from __future__ import annotations
 import logging
 import os
 from pathlib import Path

--- a/src/nodes/comment_selector/validators/duplication_validator.py
+++ b/src/nodes/comment_selector/validators/duplication_validator.py
@@ -1,5 +1,6 @@
 """重複チェックバリデーター"""
 
+from __future__ import annotations
 import logging
 
 from src.constants.validation_constants import SIMILARITY_THRESHOLD

--- a/src/nodes/comment_selector/validators/seasonal_validator.py
+++ b/src/nodes/comment_selector/validators/seasonal_validator.py
@@ -1,5 +1,6 @@
 """季節の妥当性チェックバリデーター"""
 
+from __future__ import annotations
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/nodes/comment_selector/validators/weather_consistency_validator.py
+++ b/src/nodes/comment_selector/validators/weather_consistency_validator.py
@@ -1,5 +1,6 @@
 """天気の一貫性チェックバリデーター"""
 
+from __future__ import annotations
 import logging
 
 from src.config.config import get_weather_constants

--- a/src/nodes/comment_selector/validators/yaml_config_validator.py
+++ b/src/nodes/comment_selector/validators/yaml_config_validator.py
@@ -1,5 +1,6 @@
 """YAML設定ベースのバリデーター"""
 
+from __future__ import annotations
 import logging
 from pathlib import Path
 

--- a/src/nodes/evaluate_candidate_node.py
+++ b/src/nodes/evaluate_candidate_node.py
@@ -4,6 +4,7 @@
 選択されたコメントペアを評価し、品質を検証するLangGraphノード
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 from datetime import datetime

--- a/src/nodes/generate_comment_node.py
+++ b/src/nodes/generate_comment_node.py
@@ -3,6 +3,7 @@
 LLMを使用して天気情報と過去コメントを基にコメントを生成する。
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 from datetime import datetime

--- a/src/nodes/helpers/comment_safety.py
+++ b/src/nodes/helpers/comment_safety.py
@@ -1,5 +1,6 @@
 """コメント安全性チェックモジュール"""
 
+from __future__ import annotations
 from typing import Any
 import logging
 from src.data.comment_generation_state import CommentGenerationState

--- a/src/nodes/helpers/ng_words.py
+++ b/src/nodes/helpers/ng_words.py
@@ -1,5 +1,6 @@
 """NGワード管理モジュール"""
 
+from __future__ import annotations
 from typing import Any
 import logging
 from pathlib import Path

--- a/src/nodes/helpers/temperature_analysis.py
+++ b/src/nodes/helpers/temperature_analysis.py
@@ -1,5 +1,6 @@
 """気温差分析モジュール"""
 
+from __future__ import annotations
 from typing import Any
 import logging
 from src.config.weather_config import get_config

--- a/src/nodes/helpers/time_season.py
+++ b/src/nodes/helpers/time_season.py
@@ -1,5 +1,6 @@
 """時間帯・季節判定モジュール"""
 
+from __future__ import annotations
 from datetime import datetime
 from src.utils.common_utils import get_season_from_month, get_time_period_from_hour
 

--- a/src/nodes/input_node.py
+++ b/src/nodes/input_node.py
@@ -4,6 +4,7 @@
 ユーザー入力を受け取り、初期状態を設定するLangGraphノード
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 from datetime import datetime, timedelta

--- a/src/nodes/output_node.py
+++ b/src/nodes/output_node.py
@@ -4,6 +4,7 @@
 最終結果を整形してJSON形式で出力するLangGraphノード
 """
 
+from __future__ import annotations
 from typing import Any
 import logging
 from datetime import datetime

--- a/src/nodes/retrieve_past_comments_node.py
+++ b/src/nodes/retrieve_past_comments_node.py
@@ -1,5 +1,6 @@
 """過去コメント取得ノード - ローカルCSVファイルから過去コメントを取得"""
 
+from __future__ import annotations
 import logging
 from datetime import datetime
 from typing import Any

--- a/src/nodes/select_comment_pair_node.py
+++ b/src/nodes/select_comment_pair_node.py
@@ -1,5 +1,6 @@
 """コメントペア選択ノード - LLMを使用して適切なコメントペアを選択"""
 
+from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 from typing import Any

--- a/src/nodes/unified_comment_generation_node.py
+++ b/src/nodes/unified_comment_generation_node.py
@@ -4,6 +4,7 @@
 単一のLLM呼び出しで実行することで、パフォーマンスを向上させます。
 """
 
+from __future__ import annotations
 import json
 import logging
 from typing import Any

--- a/src/nodes/weather_forecast/constants.py
+++ b/src/nodes/weather_forecast/constants.py
@@ -5,6 +5,8 @@ Weather forecast node constants
 """
 
 # API関連の定数
+
+from __future__ import annotations
 API_MAX_RETRIES = 3  # API呼び出しの最大リトライ回数
 API_INITIAL_RETRY_DELAY = 1.0  # 初回リトライ遅延（秒）
 API_RETRY_BACKOFF_MULTIPLIER = 2  # リトライ遅延の指数バックオフ乗数

--- a/src/nodes/weather_forecast/data_fetcher.py
+++ b/src/nodes/weather_forecast/data_fetcher.py
@@ -4,6 +4,7 @@
 WxTech APIを使用して天気予報データを取得する機能を提供
 """
 
+from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 from typing import Any

--- a/src/nodes/weather_forecast/data_transformer.py
+++ b/src/nodes/weather_forecast/data_transformer.py
@@ -4,6 +4,7 @@
 天気予報データの変換・加工・集計機能を提供
 """
 
+from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 from typing import Any

--- a/src/nodes/weather_forecast/data_validator.py
+++ b/src/nodes/weather_forecast/data_validator.py
@@ -4,6 +4,7 @@
 天気予報データの検証と優先度に基づく選択機能を提供
 """
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.data.weather_data import WeatherForecast, WeatherCondition

--- a/src/nodes/weather_forecast/messages.py
+++ b/src/nodes/weather_forecast/messages.py
@@ -5,6 +5,7 @@ Weather forecast error messages
 将来的な国際化（i18n）に対応できる構造
 """
 
+from __future__ import annotations
 from typing import Any
 
 

--- a/src/nodes/weather_forecast/node_handlers.py
+++ b/src/nodes/weather_forecast/node_handlers.py
@@ -3,6 +3,7 @@
 fetch_weather_forecast_nodeの処理を責務ごとに分割
 """
 
+from __future__ import annotations
 import logging
 import os
 from datetime import datetime

--- a/src/nodes/weather_forecast/service_factory.py
+++ b/src/nodes/weather_forecast/service_factory.py
@@ -4,6 +4,7 @@ Weather forecast service factory
 サービスの依存性注入を管理するファクトリークラス
 """
 
+from __future__ import annotations
 from src.nodes.weather_forecast.services import (
     LocationService,
     WeatherAPIService,

--- a/src/nodes/weather_forecast/services.py
+++ b/src/nodes/weather_forecast/services.py
@@ -5,6 +5,7 @@ Weather forecast node services
 責務ごとに分離されたサービスを提供
 """
 
+from __future__ import annotations
 import asyncio
 import logging
 import time

--- a/src/nodes/weather_forecast_node.py
+++ b/src/nodes/weather_forecast_node.py
@@ -5,6 +5,7 @@ LangGraphノードとして天気予報データの取得・処理を行う
 巨大な関数を責務ごとのサービスに分割
 """
 
+from __future__ import annotations
 import asyncio
 import logging
 import os

--- a/src/repositories/base_repository.py
+++ b/src/repositories/base_repository.py
@@ -1,5 +1,6 @@
 """リポジトリの基底クラスとインターフェース定義"""
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 from datetime import datetime

--- a/src/repositories/comment_cache.py
+++ b/src/repositories/comment_cache.py
@@ -1,5 +1,6 @@
 """コメントのキャッシュ管理を担当するクラス"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from datetime import datetime, timedelta

--- a/src/repositories/csv_file_handler.py
+++ b/src/repositories/csv_file_handler.py
@@ -1,5 +1,6 @@
 """CSVファイル操作を担当するクラス"""
 
+from __future__ import annotations
 import csv
 import logging
 from pathlib import Path

--- a/src/repositories/indexed_csv_handler.py
+++ b/src/repositories/indexed_csv_handler.py
@@ -5,6 +5,7 @@
 自動再構築機能を提供します。
 """
 
+from __future__ import annotations
 import hashlib
 import json
 import logging

--- a/src/repositories/lazy_comment_repository.py
+++ b/src/repositories/lazy_comment_repository.py
@@ -4,6 +4,7 @@ CSVファイルを必要な時だけ読み込むことで、起動時間とメ�
 並列読み込みに対応してパフォーマンスを向上
 """
 
+from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Any

--- a/src/repositories/lru_comment_cache.py
+++ b/src/repositories/lru_comment_cache.py
@@ -4,6 +4,7 @@
 スレッドセーフ実装により、並列処理環境でも安全に使用可能。
 """
 
+from __future__ import annotations
 import logging
 import threading
 from typing import Any

--- a/src/types/__init__.py
+++ b/src/types/__init__.py
@@ -16,7 +16,27 @@ from .common import (
     APIResponse
 )
 
+from .aliases import (
+    JsonDict,
+    JsonList,
+    NullableJsonDict,
+    ConfigDict,
+    StringMapping,
+    WeatherMetadata,
+    TemperatureDifferences,
+    HistoryEntry,
+    HistoryList,
+    ProgressCallback,
+    NumericStats,
+    FloatStats,
+    ApiResponse,
+    ApiErrorDetail,
+    BatchResult,
+    LocationResults
+)
+
 __all__ = [
+    # From common
     'LLMProvider',
     'WeatherCondition',
     'CommentStyle',
@@ -29,5 +49,22 @@ __all__ = [
     'HistoryItem',
     'CommentPair',
     'ValidationResult',
-    'APIResponse'
+    'APIResponse',
+    # From aliases
+    'JsonDict',
+    'JsonList',
+    'NullableJsonDict',
+    'ConfigDict',
+    'StringMapping',
+    'WeatherMetadata',
+    'TemperatureDifferences',
+    'HistoryEntry',
+    'HistoryList',
+    'ProgressCallback',
+    'NumericStats',
+    'FloatStats',
+    'ApiResponse',
+    'ApiErrorDetail',
+    'BatchResult',
+    'LocationResults'
 ]

--- a/src/types/aliases.py
+++ b/src/types/aliases.py
@@ -1,0 +1,42 @@
+"""
+共通で使用される型エイリアスの定義
+
+頻繁に使用される複雑な型をエイリアスとして定義することで、
+コードの可読性と保守性を向上させます。
+"""
+
+from __future__ import annotations
+from typing import Any
+from collections.abc import Callable
+
+# ジェネリックなデータ構造
+JsonDict = dict[str, Any]
+JsonList = list[dict[str, Any]]
+NullableJsonDict = dict[str, Any | None]
+
+# 設定とコンフィグレーション
+ConfigDict = dict[str, str | int | float | bool]
+StringMapping = dict[str, str]
+
+# 天気と地点に特化した型
+WeatherMetadata = dict[str, str | float | None]
+TemperatureDifferences = dict[str, float | None]
+
+# UI と履歴
+HistoryEntry = dict[str, str]
+HistoryList = list[dict[str, str]]
+
+# コールバック
+ProgressCallback = Callable[[int, int, str | None], None]
+
+# 統計とメトリクス
+NumericStats = dict[str, int]
+FloatStats = dict[str, float]
+
+# API レスポンス
+ApiResponse = dict[str, Any]
+ApiErrorDetail = dict[str, str | int | None]
+
+# バッチ処理結果
+BatchResult = dict[str, bool | str | list[Any] | None]
+LocationResults = list[dict[str, Any]]

--- a/src/types/api_response.py
+++ b/src/types/api_response.py
@@ -1,5 +1,6 @@
 """Unified API response types for type safety"""
 
+from __future__ import annotations
 from typing import TypeVar, Generic, Any
 from pydantic import BaseModel, Field
 from datetime import datetime

--- a/src/types/api_types.py
+++ b/src/types/api_types.py
@@ -3,6 +3,7 @@ API-related type definitions for Python 3.13+.
 This module contains type definitions for API parameters and responses.
 """
 
+from __future__ import annotations
 from typing import TypedDict, Literal, NotRequired, Any
 from dataclasses import dataclass, field
 import hashlib

--- a/src/types/cache_types.py
+++ b/src/types/cache_types.py
@@ -3,6 +3,7 @@ Cache-related type definitions for Python 3.13+.
 This module contains type definitions for TTL cache implementation.
 """
 
+from __future__ import annotations
 from typing import TypedDict, Any, Generic, TypeVar
 from datetime import datetime
 

--- a/src/types/common.py
+++ b/src/types/common.py
@@ -1,5 +1,6 @@
 """共通の型定義"""
 
+from __future__ import annotations
 from typing import TypedDict, Any, Literal
 from datetime import datetime
 from dataclasses import dataclass

--- a/src/types/function_signatures.py
+++ b/src/types/function_signatures.py
@@ -1,5 +1,6 @@
 """Standardized function signatures for consistency across the codebase"""
 
+from __future__ import annotations
 from typing import Protocol, Any 
 from datetime import datetime
 

--- a/src/types/validation.py
+++ b/src/types/validation.py
@@ -4,6 +4,7 @@
 Protocolを使用して、型の一貫性を保証
 """
 
+from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 

--- a/src/types/workflow_types.py
+++ b/src/types/workflow_types.py
@@ -3,6 +3,7 @@ Workflow-related type definitions for Python 3.13+.
 This module contains type definitions for LangGraph workflow states and metadata.
 """
 
+from __future__ import annotations
 from typing import TypedDict, NotRequired, Literal
 from datetime import datetime
 

--- a/src/ui/components/generation_history.py
+++ b/src/ui/components/generation_history.py
@@ -1,5 +1,6 @@
 """生成履歴表示コンポーネント"""
 
+from __future__ import annotations
 import streamlit as st
 from typing import Any
 from datetime import datetime

--- a/src/ui/components/llm_provider_selector.py
+++ b/src/ui/components/llm_provider_selector.py
@@ -1,5 +1,6 @@
 """LLMプロバイダー選択コンポーネント"""
 
+from __future__ import annotations
 import streamlit as st
 from typing import Any
 from src.config.app_config import get_config

--- a/src/ui/components/location_selector.py
+++ b/src/ui/components/location_selector.py
@@ -181,7 +181,7 @@ def location_selector() -> list[str]:
             default_selection = []
 
     # ソート（よく使う地点を上に）
-    sorted_locations = sort_locations_by_order(filtered_locations, st.session_state.favorite_locations)
+    sorted_locations = sort_locations_by_order(filtered_locations)
 
     selected_locations = st.multiselect(
         "📍 地点を選択",

--- a/src/ui/components/location_selector.py
+++ b/src/ui/components/location_selector.py
@@ -1,5 +1,6 @@
 """地点選択コンポーネント"""
 
+from __future__ import annotations
 import streamlit as st
 from typing import Any
 from src.ui.streamlit_utils import load_locations, filter_locations, sort_locations_by_order

--- a/src/ui/components/result_display.py
+++ b/src/ui/components/result_display.py
@@ -1,5 +1,6 @@
 """結果表示コンポーネント"""
 
+from __future__ import annotations
 import streamlit as st
 from typing import Any
 from datetime import datetime

--- a/src/ui/components/settings_panel.py
+++ b/src/ui/components/settings_panel.py
@@ -1,5 +1,6 @@
 """設定パネルコンポーネント"""
 
+from __future__ import annotations
 import streamlit as st
 import os
 from typing import Any

--- a/src/ui/pages/statistics.py
+++ b/src/ui/pages/statistics.py
@@ -4,6 +4,7 @@
 生成履歴の統計分析とデータ可視化
 """
 
+from __future__ import annotations
 import streamlit as st
 import pandas as pd
 import plotly.express as px

--- a/src/ui/streamlit_components.py
+++ b/src/ui/streamlit_components.py
@@ -7,6 +7,8 @@ Streamlit UIコンポーネント
 """
 
 # 新しいコンポーネントからインポート
+
+from __future__ import annotations
 from src.ui.components import (
     location_selector,
     llm_provider_selector,

--- a/src/ui/streamlit_utils.py
+++ b/src/ui/streamlit_utils.py
@@ -6,6 +6,8 @@ Streamlit UIユーティリティ関数
 """
 
 # 後方互換性のために全ての関数を再エクスポート
+
+from __future__ import annotations
 from .utils import (
     # Location utilities
     get_location_order,

--- a/src/ui/utils/config_utils.py
+++ b/src/ui/utils/config_utils.py
@@ -4,6 +4,7 @@
 APIキー検証、テーマ設定など
 """
 
+from __future__ import annotations
 import os
 import streamlit as st
 

--- a/src/ui/utils/error_messaging.py
+++ b/src/ui/utils/error_messaging.py
@@ -4,8 +4,10 @@
 ユーザーフレンドリーなエラーメッセージと対処法を提供
 """
 
+from __future__ import annotations
 import streamlit as st
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from enum import Enum
 import logging
 import json

--- a/src/ui/utils/feedback_components.py
+++ b/src/ui/utils/feedback_components.py
@@ -4,8 +4,10 @@
 より良いユーザー体験のためのフィードバック機能
 """
 
+from __future__ import annotations
 import streamlit as st
-from typing import Any, Callable, Literal
+from typing import Any, Literal
+from collections.abc import Callable
 from datetime import datetime
 import time
 from .security_utils import sanitize_html, sanitize_id, generate_safe_id

--- a/src/ui/utils/history_utils.py
+++ b/src/ui/utils/history_utils.py
@@ -4,6 +4,7 @@
 生成結果の保存、読み込み、エクスポートなど
 """
 
+from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any

--- a/src/ui/utils/i18n.py
+++ b/src/ui/utils/i18n.py
@@ -4,6 +4,7 @@
 多言語対応のための基本的なフレームワーク
 """
 
+from __future__ import annotations
 import json
 import os
 from typing import Any

--- a/src/ui/utils/location_utils.py
+++ b/src/ui/utils/location_utils.py
@@ -4,6 +4,7 @@
 地点の順序管理、フィルタリング、読み込みなど
 """
 
+from __future__ import annotations
 from pathlib import Path
 import pandas as pd
 import streamlit as st

--- a/src/ui/utils/responsive_design.py
+++ b/src/ui/utils/responsive_design.py
@@ -4,6 +4,7 @@
 モバイルフレンドリーなUIを実現するためのスタイリングとレイアウトヘルパー
 """
 
+from __future__ import annotations
 import streamlit as st
 from typing import Any
 from .security_utils import sanitize_html, sanitize_css_value

--- a/src/ui/utils/security_utils.py
+++ b/src/ui/utils/security_utils.py
@@ -4,6 +4,7 @@
 HTMLサニタイズ、入力検証など
 """
 
+from __future__ import annotations
 import re
 import html
 from typing import Any

--- a/src/ui/utils/statistics_utils.py
+++ b/src/ui/utils/statistics_utils.py
@@ -4,6 +4,7 @@
 履歴データからの統計情報生成など
 """
 
+from __future__ import annotations
 from typing import Any
 from datetime import datetime, date
 from collections import Counter

--- a/src/ui/utils/ui_helpers.py
+++ b/src/ui/utils/ui_helpers.py
@@ -4,8 +4,10 @@ UI関連のヘルパー関数
 クリップボード操作、ダウンロード、エラーハンドリングなど
 """
 
+from __future__ import annotations
 import base64
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from datetime import datetime
 import streamlit as st
 from .feedback_components import show_notification

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -1,12 +1,14 @@
 """APIリクエストのキャッシュ機能を提供するユーティリティ"""
 
+from __future__ import annotations
 import time
 import hashlib
 import json
 import inspect
 import threading
 import sys
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
+from collections.abc import Callable
 from functools import wraps
 import logging
 

--- a/src/utils/common_utils.py
+++ b/src/utils/common_utils.py
@@ -1,5 +1,6 @@
 """共通ユーティリティ関数"""
 
+from __future__ import annotations
 from datetime import datetime
 
 from src.constants import (

--- a/src/utils/cpu_optimizer.py
+++ b/src/utils/cpu_optimizer.py
@@ -3,6 +3,7 @@
 並列処理のワーカー数を環境に応じて最適化する。
 """
 
+from __future__ import annotations
 import os
 import logging
 

--- a/src/utils/csv_validator.py
+++ b/src/utils/csv_validator.py
@@ -1,5 +1,6 @@
 """CSVファイル検証ユーティリティ"""
 
+from __future__ import annotations
 import csv
 import logging
 from pathlib import Path

--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -1,7 +1,8 @@
 """統一されたエラーハンドリング"""
 
+from __future__ import annotations
 import logging
-from typing import Any, Callable, TypeVar 
+from typing import Any, TypeVar
 from functools import wraps
 from dataclasses import dataclass
 import traceback

--- a/src/utils/geography/coastal_detector.py
+++ b/src/utils/geography/coastal_detector.py
@@ -1,5 +1,6 @@
 """海岸線検出ユーティリティ - 緯度経度から海岸/内陸を判定（KD-Tree最適化版）"""
 
+from __future__ import annotations
 import logging
 from math import radians, sin, cos, sqrt, atan2
 import numpy as np

--- a/src/utils/parameter_helpers.py
+++ b/src/utils/parameter_helpers.py
@@ -1,5 +1,6 @@
 """Helper functions for standardizing function parameters"""
 
+from __future__ import annotations
 from typing import Any
 from datetime import datetime
 

--- a/src/utils/secure_config.py
+++ b/src/utils/secure_config.py
@@ -1,5 +1,6 @@
 """セキュアな設定管理"""
 
+from __future__ import annotations
 import os
 import json
 import base64

--- a/src/utils/validators/base_validator.py
+++ b/src/utils/validators/base_validator.py
@@ -1,5 +1,6 @@
 """ベースバリデータクラス - 共通の検証機能を提供"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from abc import ABC, abstractmethod

--- a/src/utils/validators/coastal_validator.py
+++ b/src/utils/validators/coastal_validator.py
@@ -1,5 +1,6 @@
 """海岸地域バリデータ - 海岸/内陸に基づくコメント検証"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.data.weather_data import WeatherForecast

--- a/src/utils/validators/consistency_validator.py
+++ b/src/utils/validators/consistency_validator.py
@@ -1,5 +1,6 @@
 """一貫性バリデータ - コメントペアの一貫性を検証"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.config.config import get_weather_constants

--- a/src/utils/validators/duplication_checker.py
+++ b/src/utils/validators/duplication_checker.py
@@ -1,5 +1,6 @@
 """重複チェック共通ユーティリティ"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.constants.validation_constants import (

--- a/src/utils/validators/llm_duplication_validator.py
+++ b/src/utils/validators/llm_duplication_validator.py
@@ -1,5 +1,6 @@
 """LLMを使用した動的な重複検証バリデータ"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from langchain_google_genai import ChatGoogleGenerativeAI

--- a/src/utils/validators/pollen_validator.py
+++ b/src/utils/validators/pollen_validator.py
@@ -1,5 +1,6 @@
 """花粉関連のコメント検証"""
 
+from __future__ import annotations
 import logging
 from datetime import datetime
 

--- a/src/utils/validators/regional_validator.py
+++ b/src/utils/validators/regional_validator.py
@@ -1,5 +1,6 @@
 """地域特性バリデータ - 地域に基づくコメント検証"""
 
+from __future__ import annotations
 import logging
 
 from src.data.weather_data import WeatherForecast

--- a/src/utils/validators/temperature_validator.py
+++ b/src/utils/validators/temperature_validator.py
@@ -1,5 +1,6 @@
 """温度条件バリデータ - 気温に基づくコメント検証"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.config.config import get_weather_constants

--- a/src/utils/validators/weather_comment_validator.py
+++ b/src/utils/validators/weather_comment_validator.py
@@ -1,7 +1,7 @@
 """天気コメント検証システム - メインバリデータ"""
 
 import logging
-from typing import Dict, Any, TypedDict
+from typing import Any, TypedDict
 from datetime import datetime
 
 from src.config.config import get_weather_constants

--- a/src/utils/validators/weather_comment_validator.py
+++ b/src/utils/validators/weather_comment_validator.py
@@ -1,5 +1,6 @@
 """天気コメント検証システム - メインバリデータ"""
 
+from __future__ import annotations
 import logging
 from typing import Any, TypedDict
 from datetime import datetime

--- a/src/utils/validators/weather_specific/consistency_validator.py
+++ b/src/utils/validators/weather_specific/consistency_validator.py
@@ -1,5 +1,6 @@
 """一貫性バリデーター - コメントペアの一貫性を検証"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 import re

--- a/src/utils/validators/weather_specific/regional_specifics_validator.py
+++ b/src/utils/validators/weather_specific/regional_specifics_validator.py
@@ -1,5 +1,6 @@
 """地域特性バリデーター - 地域特性に基づいてコメントの適切性を検証"""
 
+from __future__ import annotations
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/utils/validators/weather_specific/temperature_condition_validator.py
+++ b/src/utils/validators/weather_specific/temperature_condition_validator.py
@@ -1,5 +1,6 @@
 """温度条件バリデーター - 温度条件に基づいてコメントの適切性を検証"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.config.config import get_weather_constants

--- a/src/utils/validators/weather_specific/weather_comment_validator_refactored.py
+++ b/src/utils/validators/weather_specific/weather_comment_validator_refactored.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Tuple, TYPE_CHECKING, Named
+from typing import TYPE_CHECKING, NamedTuple
 from datetime import datetime
 
 if TYPE_CHECKING:

--- a/src/utils/validators/weather_specific/weather_condition_validator.py
+++ b/src/utils/validators/weather_specific/weather_condition_validator.py
@@ -1,5 +1,6 @@
 """天気条件バリデーター - 天気条件に基づいてコメントの適切性を検証"""
 
+from __future__ import annotations
 import logging
 import yaml
 from pathlib import Path

--- a/src/utils/validators/weather_transition_validator.py
+++ b/src/utils/validators/weather_transition_validator.py
@@ -1,5 +1,6 @@
 """天気推移バリデータ - 天気の時系列変化に基づくコメント検証"""
 
+from __future__ import annotations
 import logging
 from typing import Any
 from src.data.weather_data import WeatherForecast, WeatherCondition

--- a/src/utils/validators/weather_validator.py
+++ b/src/utils/validators/weather_validator.py
@@ -1,7 +1,7 @@
 """天気条件バリデータ - 天気状態に基づくコメント検証"""
 
 import logging
-from typing import Dict, TypedDict
+from typing import TypedDict
 
 from src.config.config import get_weather_constants
 

--- a/src/utils/validators/weather_validator.py
+++ b/src/utils/validators/weather_validator.py
@@ -1,5 +1,6 @@
 """天気条件バリデータ - 天気状態に基づくコメント検証"""
 
+from __future__ import annotations
 import logging
 from typing import TypedDict
 

--- a/src/utils/weather_classifier.py
+++ b/src/utils/weather_classifier.py
@@ -1,5 +1,6 @@
 """天気タイプ分類ユーティリティ"""
 
+from __future__ import annotations
 from src.config.config import get_weather_constants
 
 # 定数を取得

--- a/src/utils/weather_comment_validator.py
+++ b/src/utils/weather_comment_validator.py
@@ -1,5 +1,6 @@
 """天気コメント検証システム - 互換性のためのエイリアス"""
 
+from __future__ import annotations
 import warnings
 
 # 後方互換性のため、validators パッケージから WeatherCommentValidator をインポート

--- a/src/workflows/comment_generation_workflow.py
+++ b/src/workflows/comment_generation_workflow.py
@@ -4,6 +4,7 @@
 パフォーマンスを最適化したワークフローです。
 """
 
+from __future__ import annotations
 from typing import Any
 from datetime import datetime, timedelta
 import time

--- a/src/workflows/unified_comment_generation_workflow.py
+++ b/src/workflows/unified_comment_generation_workflow.py
@@ -4,6 +4,7 @@
 既存のワークフローと完全な互換性を保ちます。
 """
 
+from __future__ import annotations
 from typing import Any
 from datetime import datetime, timedelta
 import time

--- a/src/workflows/workflow_executor.py
+++ b/src/workflows/workflow_executor.py
@@ -3,6 +3,7 @@
 巨大なrun_comment_generation関数を分割し、責務を明確化。
 """
 
+from __future__ import annotations
 import json
 import logging
 from typing import Any


### PR DESCRIPTION
- Dict[K, V] → dict[K, V]
- List[T] → list[T]
- Optional[T] → T | None
- Union[A, B] → A | B
- 型ヒント変換スクリプトのバグ修正（TypedDictの誤変換を防止）
- Callable型ヒントの構文エラーを修正
- 不要な型インポートを削除

