### PR TITLE
refactor: unified_config.pyの参照を削除

### DIFF
--- a/src/config/app_settings.py
+++ b/src/config/app_settings.py
@@ -85,7 +85,7 @@ _env_loaded = False
 
 
 def get_config() -> AppConfig:
-    """グローバル設定インスタンスを取得（非推奨: get_unified_configを使用してください）
+    """グローバル設定インスタンスを取得
 
     Returns:
         アプリケーション設定

--- a/src/config/app_settings.py
+++ b/src/config/app_settings.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from dotenv import load_dotenv
 
-from .config import get_system_constants, get_weather_config, get_langgraph_config, get_config
+from .config import get_system_constants, get_weather_config, get_langgraph_config, get_config as get_base_config
 
 # 定数を取得
 _sys_const = get_system_constants()
@@ -34,7 +34,8 @@ class AppConfig:
 
     def __init__(self):
         """統一設定から初期化"""
-        config = get_config()
+        # 循環参照を避けるため、直接設定を取得
+        config = get_base_config()
         self.weather = config.weather
         self.langgraph = config.langgraph
         self.debug_mode = config.app.debug

--- a/src/config/app_settings.py
+++ b/src/config/app_settings.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from dotenv import load_dotenv
 
-from .config import get_system_constants, get_weather_config, get_langgraph_config, get_config as get_unified_config
+from .config import get_system_constants, get_weather_config, get_langgraph_config, get_config
 
 # 定数を取得
 _sys_const = get_system_constants()
@@ -34,11 +34,11 @@ class AppConfig:
 
     def __init__(self):
         """統一設定から初期化"""
-        unified_config = get_unified_config()
-        self.weather = unified_config.weather
-        self.langgraph = unified_config.langgraph
-        self.debug_mode = unified_config.app.debug
-        self.log_level = unified_config.app.log_level
+        config = get_config()
+        self.weather = config.weather
+        self.langgraph = config.langgraph
+        self.debug_mode = config.app.debug
+        self.log_level = config.app.log_level
 
     def to_dict(self) -> dict[str, Any]:
         """辞書形式に変換

--- a/test_config_issue.py
+++ b/test_config_issue.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+"""設定読み込みエラーのテスト"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    print("Testing config import...")
+    from src.config.app_settings import get_config
+    print("Import successful")
+    
+    print("Getting config instance...")
+    config = get_config()
+    print("Config loaded successfully")
+    print(f"Weather location: {config.weather.default_location}")
+    
+except Exception as e:
+    print(f"Error: {type(e).__name__}: {e}")
+    import traceback
+    traceback.print_exc()

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -2,7 +2,6 @@
 
 import pytest
 from src.config.config import reset_config
-from src.config.unified_config import UnifiedConfig
 
 
 @pytest.fixture(autouse=True)
@@ -10,10 +9,8 @@ def reset_config_singleton():
     """各テストの前後で設定シングルトンをリセット"""
     # テスト前にリセット
     reset_config()
-    UnifiedConfig._instance = None
     
     yield
     
     # テスト後にもリセット
     reset_config()
-    UnifiedConfig._instance = None


### PR DESCRIPTION
- tests/config/conftest.py: UnifiedConfig._instanceのリセットを削除
- src/config/app_settings.py: get_unified_configエイリアスを削除、直接get_configを使用
- 後方互換性は維持（unified_config.pyは非推奨警告付きで残存）

